### PR TITLE
Remove warnings during content color depedency resolution

### DIFF
--- a/content-color/build.gradle.kts
+++ b/content-color/build.gradle.kts
@@ -31,15 +31,15 @@ kotlin {
         // nativeMain an jsMain require the compileOny libraries be included.
         val nativeMain by getting {
             dependencies {
-                implementation(compose.material)
-                implementation(compose.material3)
+                api(compose.material)
+                api(compose.material3)
             }
         }
 
         val jsMain by getting {
             dependencies {
-                implementation(compose.material)
-                implementation(compose.material3)
+                api(compose.material)
+                api(compose.material3)
             }
         }
     }


### PR DESCRIPTION
On native and JS targets gradle implementation automatically changes to api to bundle libs. So to remove the warnings setting material to include via api 