### PR TITLE
Experimental Modifiers

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,40 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -40,6 +40,9 @@
     <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.0" />
+    <option name="version" value="2.2.0" />
   </component>
 </project>

--- a/foundations/api/api.txt
+++ b/foundations/api/api.txt
@@ -9,6 +9,26 @@ package io.daio.wild.foundation {
     method public static androidx.compose.ui.Modifier selectable(androidx.compose.ui.Modifier, boolean selected, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional androidx.compose.foundation.Indication? indication, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
   }
 
+  public final class Clickable_androidKt {
+    method public static int getRepeatCount(android.view.KeyEvent);
+  }
+
+  public final class Clickable_jsKt {
+    method public static int getRepeatCount(android.view.KeyEvent);
+  }
+
+  public final class Clickable_jvmKt {
+    method public static int getRepeatCount(android.view.KeyEvent);
+  }
+
+  public final class Clickable_nativeKt {
+    method public static int getRepeatCount(android.view.KeyEvent);
+  }
+
+  public final class Clickable_wasmJsKt {
+    method public static int getRepeatCount(android.view.KeyEvent);
+  }
+
   @kotlin.RequiresOptIn(message="This API is experimental and may change or be removed.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public @interface ExperimentalWildApi {
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ org.gradle.android.cache-fix.ignoreVersionCheck=true
 
 ## RELEASE DETAILS ##
 GROUP=io.daio.wild
-VERSION_NAME=0.3.4
+VERSION_NAME=0.4.0
 
 SONATYPE_HOST=CENTRAL_PORTAL
 RELEASE_SIGNING_ENABLED=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 agp = "8.12.0"
 activity-compose = "1.10.1"
 androidx-appcompat = "1.7.1"
+benchmark = "1.4.0"
 compose-compiler = "1.5.7.1"
 compose-uitooling = "1.5.4"
 detekt = "1.23.8"
@@ -17,9 +18,10 @@ compose-multiplatform = "1.8.2"
 core-ktx = "1.15.0"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.3.0"
-espresso-core = "3.6.1"
+espresso-core = "3.7.0"
 lifecycle-runtime-ktx = "2.9.2"
 metalava = "0.4.0-alpha03"
+uiautomator = "2.3.0"
 
 [libraries]
 # TV
@@ -40,6 +42,8 @@ ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-rules-detekt = { module = "io.nlopez.compose.rules:detekt", version = "0.4.26" }
 tools-desugarjdklibs = "com.android.tools:desugar_jdk_libs:2.1.5"
+androidx-benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark" }
+androidx-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 
 # Build logic dependencies
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/internal/benchmark/build.gradle.kts
+++ b/internal/benchmark/build.gradle.kts
@@ -1,0 +1,28 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+import io.daio.gradle.Versions
+
+plugins {
+    id("io.daio.android.test")
+    id("io.daio.kotlin.android")
+}
+
+@Suppress("UnstableApiUsage")
+android {
+    namespace = "io.daio.wild.benchmark"
+
+    defaultConfig {
+        minSdk = Versions.MIN_SDK
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+    }
+
+    targetProjectPath = ":playbook:androidTv"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+dependencies {
+    implementation(libs.androidx.benchmark.macro)
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.test.uiautomator)
+}

--- a/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTests.kt
+++ b/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTests.kt
@@ -1,0 +1,127 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.benchmark
+
+import android.view.KeyEvent
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.UiDevice
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val DEFAULT_ITERATIONS = 20
+private const val APP_PACKAGE = "io.daio.wild.playbook.tv"
+
+@RunWith(AndroidJUnit4::class)
+class TvBenchmarkTest {
+    @get:Rule
+    val benchmarkRule: MacrobenchmarkRule = MacrobenchmarkRule()
+
+    /**
+     * Using a Modifier that sets up and adjusts styles using a Modifier.composed solution.
+     */
+    @Test
+    fun scrollGridWithWildComposedModifier() {
+        benchmarkRule.measureRepeated(
+            packageName = APP_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            startupMode = StartupMode.WARM,
+            iterations = DEFAULT_ITERATIONS,
+            setupBlock = {
+                startActivityAndWait {
+                    it.putExtra("MODE", "grid")
+                    it.putExtra("ITEMS", "modifier")
+                }
+            },
+        ) {
+            device.scrollWithRemote()
+        }
+    }
+
+    /**
+     * Using a Modifier that sets up and adjusts styles using custom Node implementations.
+     */
+    @Test
+    fun scrollGridWithWildExperimentalModifier() {
+        benchmarkRule.measureRepeated(
+            packageName = APP_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            startupMode = StartupMode.WARM,
+            iterations = DEFAULT_ITERATIONS,
+            setupBlock = {
+                startActivityAndWait {
+                    it.putExtra("MODE", "grid")
+                    it.putExtra("ITEMS", "experimental_modifier")
+                }
+            },
+        ) {
+            device.scrollWithRemote()
+        }
+    }
+
+    /**
+     * Uses Tv Material Surface.
+     */
+    @Test
+    fun scrollGridWithMaterialSurface() {
+        benchmarkRule.measureRepeated(
+            packageName = APP_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            startupMode = StartupMode.WARM,
+            iterations = DEFAULT_ITERATIONS,
+            setupBlock = {
+                startActivityAndWait {
+                    it.putExtra("MODE", "grid")
+                    it.putExtra("ITEMS", "surface")
+                }
+            },
+        ) {
+            device.scrollWithRemote()
+        }
+    }
+
+    /**
+     * Uses Wild Container to setup styles.
+     */
+    @Test
+    fun scrollGridWildContainer() {
+        benchmarkRule.measureRepeated(
+            packageName = APP_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            startupMode = StartupMode.WARM,
+            iterations = DEFAULT_ITERATIONS,
+            setupBlock = {
+                startActivityAndWait {
+                    it.putExtra("MODE", "grid")
+                    it.putExtra("ITEMS", "container")
+                }
+            },
+        ) {
+            device.scrollWithRemote()
+        }
+    }
+}
+
+fun UiDevice.scrollWithRemote() {
+    runBlocking {
+        repeat(15) {
+            pressKeyCode(KeyEvent.KEYCODE_DPAD_RIGHT)
+        }
+        repeat(10) {
+            pressKeyCode(KeyEvent.KEYCODE_DPAD_DOWN)
+        }
+        repeat(15) {
+            pressKeyCode(KeyEvent.KEYCODE_DPAD_RIGHT)
+        }
+        repeat(10) {
+            pressKeyCode(KeyEvent.KEYCODE_DPAD_LEFT)
+        }
+        repeat(5) {
+            pressKeyCode(KeyEvent.KEYCODE_DPAD_UP)
+        }
+    }
+}

--- a/layout/container/api/api.txt
+++ b/layout/container/api/api.txt
@@ -4,6 +4,7 @@ package io.daio.wild.container {
   public final class ContainerKt {
     method @androidx.compose.runtime.Composable public static void Container(optional androidx.compose.ui.Modifier modifier, optional long color, optional long contentColor, optional androidx.compose.ui.graphics.Shape shape, optional io.daio.wild.style.Border border, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
     method @androidx.compose.runtime.Composable public static void Container(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, optional io.daio.wild.style.Style style, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional Boolean? selected, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void ExperimentalContainer(kotlin.jvm.functions.Function0<kotlin.Unit> onClick, optional androidx.compose.ui.Modifier modifier, optional boolean enabled, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, optional io.daio.wild.style.Style style, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional Boolean? selected, kotlin.jvm.functions.Function1<? super androidx.compose.foundation.layout.BoxScope,kotlin.Unit> content);
   }
 
 }

--- a/layout/container/src/commonMain/kotlin/io/daio/wild/container/Container.kt
+++ b/layout/container/src/commonMain/kotlin/io/daio/wild/container/Container.kt
@@ -21,6 +21,7 @@ import io.daio.wild.style.Border
 import io.daio.wild.style.BorderDefaults
 import io.daio.wild.style.Style
 import io.daio.wild.style.StyleDefaults
+import io.daio.wild.style.experimentalInteractable
 import io.daio.wild.style.interactable
 import io.daio.wild.style.interactionStyle
 
@@ -158,6 +159,123 @@ fun Container(
     Box(
         modifier =
             modifier.interactable(
+                selected = selected,
+                enabled = enabled,
+                style = style,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                interactionSource = interactionSource,
+            ),
+        propagateMinConstraints = true,
+        content = {
+            val focused by interactionSource.collectIsFocusedAsState()
+            val pressed by interactionSource.collectIsPressedAsState()
+            val hovered by interactionSource.collectIsHoveredAsState()
+            ProvidesContentColor(
+                style.colors.contentColorFor(
+                    enabled = enabled,
+                    focused = focused,
+                    hovered = hovered,
+                    pressed = pressed,
+                    selected = selected ?: false,
+                ),
+            ) {
+                content()
+            }
+        },
+    )
+}
+
+/**
+ * [ExperimentalContainer] is a building block component that can be used for any selectable TV
+ * element or on its own as a selectable container. The [Container] handles an additional
+ * state compared to [Container] to indicate whether it is currently selected.
+ *
+ * The experimental version uses the []
+ *
+ * @param onClick Callback to be called when the container is clicked. If this and [onLongClick]
+ * are null, the container will not be focusable on TV.
+ * @param modifier Modifier to be applied to the layout corresponding to the container.
+ * @param enabled Whether or not the container is enabled.
+ * @param selected Whether or not the container is currently selected.
+ * @param onLongClick Callback to be called when the container is long clicked. If this and
+ * [onClick] are null, the container will not be focusable on TV.
+ * @param style The [Style] to supply to the Container. See [StyleDefaults.style].
+ * @param interactionSource An optional hoisted [MutableInteractionSource] for observing and
+ * emitting [Interaction]s for this container.
+ * @param content Defines the [Composable] content inside the container.
+ *
+ * Example:
+ * ```
+ * ExperimentalContainer(
+ *     style =
+ *         StyleDefaults.style(
+ *             colors = StyleDefaults.colors(
+ *                 backgroundColor = Color.Black,
+ *                 contentColor = Color.White,
+ *                 focusedBackgroundColor = Color.Blue,
+ *                 focusedContentColor = Color.Yellow,
+ *                 pressedBackgroundColor = Color.Black.copy(alpha = 0.6f)
+ *             ),
+ *             scale = StyleDefaults.scale(focusedScale = 1.1f),
+ *             shapes = StyleDefaults.shapes(RoundedCornerShape(8.dp))
+ *         ),
+ *     modifier = Modifier.size(300.dp, 100.dp),
+ *     onClick = { /* Handle click */ },
+ *     onLongClick = { /* Handle long click */ }
+ * ) {
+ *     val color = LocalContentColor.current
+ *     BasicText(text = "Interactive Container", color = { color })
+ * }
+ * ```
+ *
+ * Example usage as a selectable container.
+ * ```
+ * var selected by remember { mutableStateOf(false) }
+ * ExperimentalContainer(
+ *     onClick = {
+ *         selected = !selected
+ *     },
+ *     selected = selected,
+ *     style =
+ *         StyleDefaults.style(
+ *             colors = StyleDefaults.colors(
+ *                 backgroundColor = if (selected) Color.Green else Color.Black,
+ *                 contentColor = Color.White,
+ *                 focusedBackgroundColor = Color.Red,
+ *                 focusedContentColor = Color.Black,
+ *                 pressedBackgroundColor = Color.Black.copy(alpha = 0.6f)
+ *             ),
+ *             scale = StyleDefaults.scale(focusedScale = 1.1f),
+ *             shapes = StyleDefaults.shapes(RoundedCornerShape(8.dp))
+ *         )
+ * ) {
+ *     val color = LocalContentColor.current
+ *     BasicText(
+ *         text = if (selected) "Selected Container" else "Unselected Container",
+ *         color = { color },
+ *     )
+ * }
+ * ```
+ * @since 0.4.0
+ */
+@Composable
+fun ExperimentalContainer(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onLongClick: (() -> Unit)? = null,
+    style: Style = StyleDefaults.None,
+    interactionSource: MutableInteractionSource? = null,
+    selected: Boolean? = null,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    @Suppress("NAME_SHADOWING")
+    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    Box(
+        modifier =
+            modifier.experimentalInteractable(
                 selected = selected,
                 enabled = enabled,
                 style = style,

--- a/playbook/androidTv/build.gradle.kts
+++ b/playbook/androidTv/build.gradle.kts
@@ -15,4 +15,28 @@ dependencies {
 
 android {
     namespace = "io.daio.wild.playbook.tv"
+
+    defaultConfig {
+        versionCode = 1
+        versionName = "1.0.0"
+        applicationId = "io.daio.wild.playbook.tv"
+        testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+    }
+
+    buildTypes {
+        debug {
+            isDebuggable = false
+        }
+        release {
+            isDebuggable = false
+
+            isMinifyEnabled = true
+            isShrinkResources = true
+            signingConfig = signingConfigs["debug"]
+            proguardFiles(
+                "proguard-rules.pro",
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+            )
+        }
+    }
 }

--- a/playbook/androidTv/src/main/AndroidManifest.xml
+++ b/playbook/androidTv/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
@@ -7,6 +8,11 @@
         android:allowBackup="false"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+
+        <profileable
+            android:shell="true"
+            tools:targetApi="29" />
+
         <activity android:name="io.daio.android.tv.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/MainActivity.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/MainActivity.kt
@@ -9,8 +9,10 @@ import androidx.activity.compose.setContent
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val mode = intent.getStringExtra("MODE") ?: "grid"
+        val items = intent.getStringExtra("ITEMS") ?: "container"
         setContent {
-            TvLayout()
+            TvLayout(itemsType = items, mode = mode)
         }
     }
 }

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -2,90 +2,158 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.android.tv
 
-import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.daio.common.CustomDesignSystemApp
-import io.daio.wild.components.button.Button
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.Surface
 import io.daio.wild.container.Container
 import io.daio.wild.content.LocalContentColor
 import io.daio.wild.style.Border
 import io.daio.wild.style.StyleDefaults
+import io.daio.wild.style.clickable
+import io.daio.wild.style.experimentalClickable
 
-enum class Screen {
-    Main,
-    CustomDs,
-    Material3,
-    MaterialTv,
+@Composable
+fun TvLayout(
+    modifier: Modifier = Modifier,
+    mode: String = "list",
+    itemsType: String = "container",
+) {
+    when (mode) {
+        "list" -> OptionsList(itemsType, modifier)
+        "grid" -> OptionsGrid(itemsType, modifier)
+    }
 }
 
 @Composable
-fun TvLayout(modifier: Modifier = Modifier) {
-    var currentScreen by remember { mutableStateOf(Screen.Main) }
+private fun OptionsGrid(
+    itemsType: String,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier =
+            modifier
+                .background(Color.Black)
+                .fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        repeat(20) {
+            item(key = it) {
+                LazyRow {
+                    repeat(100) { i ->
+                        item(key = i) {
+                            when (itemsType) {
+                                "container" -> {
+                                    ContainerItem(
+                                        title = itemsType,
+                                        onClick = { },
+                                    )
+                                }
 
-    BackHandler(currentScreen != Screen.Main) {
-        currentScreen = Screen.Main
-    }
+                                "surface" -> {
+                                    SurfaceItem(
+                                        title = itemsType,
+                                        onClick = { },
+                                    )
+                                }
 
-    Container(color = Color.Black) {
-        when (currentScreen) {
-            Screen.Main ->
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement =
-                        Arrangement.spacedBy(
-                            16.dp,
-                            alignment = Alignment.CenterVertically,
-                        ),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    NavigationButton(
-                        title = "Custom Design System Example",
-                        onClick = {
-                            currentScreen = Screen.CustomDs
-                        },
-                    )
-                    NavigationButton(
-                        title = "Material 3 on Tv Example",
-                        onClick = {
-                            currentScreen = Screen.Material3
-                        },
-                    )
-                    NavigationButton(
-                        title = "Material Tv Example",
-                        onClick = {
-                            currentScreen = Screen.MaterialTv
-                        },
-                    )
+                                "modifier" -> {
+                                    ModifierItem(
+                                        title = itemsType,
+                                        onClick = { },
+                                    )
+                                }
+
+                                "experimental_modifier" -> {
+                                    ExperimentalModifierItem(
+                                        title = itemsType,
+                                        onClick = { },
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
-
-            Screen.CustomDs -> CustomDesignSystemApp(modifier)
-            Screen.Material3 -> TODO()
-            Screen.MaterialTv -> TODO()
+            }
         }
     }
 }
 
 @Composable
-private fun NavigationButton(
+private fun OptionsList(
+    itemsType: String,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier =
+            modifier
+                .background(Color.Black)
+                .fillMaxSize(),
+        verticalArrangement =
+            Arrangement.spacedBy(
+                16.dp,
+                alignment = Alignment.CenterVertically,
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        repeat(100) {
+            item(key = it) {
+                when (itemsType) {
+                    "container" -> {
+                        ContainerItem(
+                            title = itemsType,
+                            onClick = { },
+                        )
+                    }
+
+                    "surface" -> {
+                        SurfaceItem(
+                            title = itemsType,
+                            onClick = { },
+                        )
+                    }
+
+                    "modifier" -> {
+                        ModifierItem(
+                            title = itemsType,
+                            onClick = { },
+                        )
+                    }
+
+                    "experimental_modifier" -> {
+                        ExperimentalModifierItem(
+                            title = itemsType,
+                            onClick = { },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContainerItem(
     title: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Button(
+    Container(
         style =
             StyleDefaults.style(
                 colors =
@@ -95,6 +163,7 @@ private fun NavigationButton(
                         focusedBackgroundColor = Color.Red,
                         focusedContentColor = Color.Black,
                         pressedBackgroundColor = Color.Black.copy(alpha = .6f),
+                        disabledBackgroundColor = Color.Black.copy(alpha = .3f),
                     ),
                 borders =
                     StyleDefaults.borders(
@@ -108,8 +177,137 @@ private fun NavigationButton(
                 scale = StyleDefaults.scale(focusedScale = 1.2f),
                 shapes = StyleDefaults.shapes(RoundedCornerShape(8.dp)),
             ),
-        modifier = modifier.width(200.dp),
+        modifier =
+            modifier
+                .size(100.dp),
         onClick = onClick,
+    ) {
+        val color = LocalContentColor.current
+        BasicText(text = title, color = { color })
+    }
+}
+
+@Composable
+private fun SurfaceItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Surface(
+        modifier =
+            modifier
+                .size(100.dp),
+        interactionSource = interactionSource,
+        onClick = onClick,
+        colors =
+            ClickableSurfaceDefaults.colors(
+                containerColor = Color.Black,
+                contentColor = Color.White,
+                focusedContainerColor = Color.Red,
+                focusedContentColor = Color.Black,
+                pressedContainerColor = Color.Black.copy(alpha = .6f),
+                disabledContainerColor = Color.Black.copy(alpha = .3f),
+            ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.2f),
+        border =
+            ClickableSurfaceDefaults.border(
+                border =
+                    androidx.tv.material3.Border(
+                        border = BorderStroke(width = 2.dp, Color.Red),
+                        inset = 2.dp,
+                    ),
+            ),
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+    ) {
+        val color = LocalContentColor.current
+        BasicText(text = title, color = { color })
+    }
+}
+
+@Composable
+private fun ModifierItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Box(
+        modifier =
+            modifier
+                .size(100.dp)
+                .clickable(
+                    onClick = onClick,
+                    interactionSource = interactionSource,
+                    style =
+                        StyleDefaults.style(
+                            colors =
+                                StyleDefaults.colors(
+                                    backgroundColor = Color.Black,
+                                    contentColor = Color.White,
+                                    focusedBackgroundColor = Color.Red,
+                                    focusedContentColor = Color.Black,
+                                    pressedBackgroundColor = Color.Black.copy(alpha = .6f),
+                                    disabledBackgroundColor = Color.Black.copy(alpha = .3f),
+                                ),
+                            borders =
+                                StyleDefaults.borders(
+                                    border =
+                                        Border(
+                                            width = 2.dp,
+                                            inset = 2.dp,
+                                            color = Color.Red,
+                                        ),
+                                ),
+                            scale = StyleDefaults.scale(focusedScale = 1.2f),
+                            shapes = StyleDefaults.shapes(RoundedCornerShape(8.dp)),
+                        ),
+                ),
+    ) {
+        val color = LocalContentColor.current
+        BasicText(text = title, color = { color })
+    }
+}
+
+@Composable
+private fun ExperimentalModifierItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Box(
+        modifier =
+            modifier
+                .size(100.dp)
+                .experimentalClickable(
+                    onClick = onClick,
+                    interactionSource = interactionSource,
+                    style =
+                        StyleDefaults.style(
+                            colors =
+                                StyleDefaults.colors(
+                                    backgroundColor = Color.Black,
+                                    contentColor = Color.White,
+                                    focusedBackgroundColor = Color.Red,
+                                    focusedContentColor = Color.Black,
+                                    pressedBackgroundColor = Color.Black.copy(alpha = .6f),
+                                    disabledBackgroundColor = Color.Black.copy(alpha = .3f),
+                                ),
+                            borders =
+                                StyleDefaults.borders(
+                                    border =
+                                        Border(
+                                            width = 2.dp,
+                                            inset = 2.dp,
+                                            color = Color.Red,
+                                        ),
+                                ),
+                            scale = StyleDefaults.scale(focusedScale = 1.2f),
+                            shapes = StyleDefaults.shapes(RoundedCornerShape(8.dp)),
+                        ),
+                ),
     ) {
         val color = LocalContentColor.current
         BasicText(text = title, color = { color })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,11 @@ include(
     ":layout:container",
 )
 
+// Test
+include(
+    ":internal:benchmark",
+)
+
 // Playbook
 include(
     ":playbook:android",

--- a/style/api/api.txt
+++ b/style/api/api.txt
@@ -75,15 +75,6 @@ package io.daio.wild.style {
 
   public final class BorderKt {
     method @androidx.compose.runtime.Stable public static io.daio.wild.style.Border Border(optional float width, optional long color, optional float inset, optional androidx.compose.ui.graphics.Shape shape);
-    method public static androidx.compose.ui.Modifier border(androidx.compose.ui.Modifier, optional androidx.compose.ui.graphics.Shape shape, optional float width, optional androidx.compose.foundation.BorderStroke borderStroke, optional float inset);
-    method public static androidx.compose.ui.Modifier border(androidx.compose.ui.Modifier, io.daio.wild.style.Border border);
-  }
-
-  public class BorderNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.DrawModifierNode {
-    ctor public BorderNode(androidx.compose.ui.graphics.Shape shape, androidx.compose.foundation.BorderStroke borderStroke, float inset);
-    method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
-    method public final void drawBorder(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
-    method public final void updateBorder(androidx.compose.ui.graphics.Shape newShape, androidx.compose.foundation.BorderStroke newBorderStroke, float newInset);
   }
 
   @androidx.compose.runtime.Immutable public final class Borders {
@@ -133,11 +124,14 @@ package io.daio.wild.style {
 
   public final class ClickableKt {
     method public static androidx.compose.ui.Modifier clickable(androidx.compose.ui.Modifier, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional io.daio.wild.style.Style? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
-    method public static androidx.compose.ui.Modifier clickable(androidx.compose.ui.Modifier, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit>? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
+    method public static androidx.compose.ui.Modifier experimentalClickable(androidx.compose.ui.Modifier, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional io.daio.wild.style.Style? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
+    method public static androidx.compose.ui.Modifier experimentalClickable(androidx.compose.ui.Modifier, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit>? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
+    method public static androidx.compose.ui.Modifier experimentalInteractable(androidx.compose.ui.Modifier, optional boolean enabled, optional Boolean? selected, optional io.daio.wild.style.Style? style, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
+    method public static androidx.compose.ui.Modifier experimentalInteractable(androidx.compose.ui.Modifier, optional boolean enabled, optional Boolean? selected, optional kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit>? style, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
+    method public static androidx.compose.ui.Modifier experimentalSelectable(androidx.compose.ui.Modifier, boolean selected, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional io.daio.wild.style.Style? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
+    method public static androidx.compose.ui.Modifier experimentalSelectable(androidx.compose.ui.Modifier, boolean selected, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit>? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
     method public static androidx.compose.ui.Modifier interactable(androidx.compose.ui.Modifier, optional boolean enabled, optional Boolean? selected, optional io.daio.wild.style.Style? style, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
-    method public static androidx.compose.ui.Modifier interactable(androidx.compose.ui.Modifier, optional boolean enabled, optional Boolean? selected, optional kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit>? style, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
     method public static androidx.compose.ui.Modifier selectable(androidx.compose.ui.Modifier, boolean selected, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional io.daio.wild.style.Style? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
-    method public static androidx.compose.ui.Modifier selectable(androidx.compose.ui.Modifier, boolean selected, optional boolean enabled, optional androidx.compose.foundation.interaction.MutableInteractionSource? interactionSource, optional kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit>? style, optional androidx.compose.ui.semantics.Role? role, optional kotlin.jvm.functions.Function0<kotlin.Unit>? onLongClick, kotlin.jvm.functions.Function0<kotlin.Unit> onClick);
   }
 
   @androidx.compose.runtime.Immutable public final class Colors {
@@ -352,7 +346,8 @@ package io.daio.wild.style {
   }
 
   public final class StyleKt {
-    method @androidx.compose.runtime.Stable public static androidx.compose.foundation.IndicationNodeFactory hardwareInputStyleIndication(optional io.daio.wild.style.Style style);
+    method public static androidx.compose.ui.Modifier experimentalInteractionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, io.daio.wild.style.Style style);
+    method public static androidx.compose.ui.Modifier experimentalInteractionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit> block);
     method public static androidx.compose.ui.Modifier interactionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, io.daio.wild.style.Style style);
     method public static androidx.compose.ui.Modifier interactionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit> block);
   }
@@ -376,6 +371,48 @@ package io.daio.wild.style {
   }
 
   @kotlin.DslMarker public @interface StyleScopeDslMarker {
+  }
+
+}
+
+package io.daio.wild.style.modifiers {
+
+  public final class BorderElementKt {
+    method public static androidx.compose.ui.Modifier border(androidx.compose.ui.Modifier, optional androidx.compose.ui.graphics.Shape shape, optional float width, optional androidx.compose.foundation.BorderStroke borderStroke, optional float inset);
+    method public static androidx.compose.ui.Modifier border(androidx.compose.ui.Modifier, io.daio.wild.style.Border border);
+  }
+
+  public final class DefaultInteractionSourceChildTraversalKey {
+    field public static final io.daio.wild.style.modifiers.DefaultInteractionSourceChildTraversalKey INSTANCE;
+  }
+
+  public final class InteractionSourceElementKt {
+    method @io.daio.wild.foundation.ExperimentalWildApi public static androidx.compose.ui.Modifier interactionSourceNode(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional Object childTraversalKey);
+  }
+
+  public interface InteractionSourceObserverNode extends androidx.compose.ui.node.TraversableNode {
+    method public void onInteractionStateChanged(io.daio.wild.style.modifiers.Interactions interactions);
+  }
+
+  @androidx.compose.runtime.Immutable public final class Interactions {
+    ctor public Interactions(boolean focused, boolean hovered, boolean pressed);
+    method public boolean component1();
+    method public boolean component2();
+    method public boolean component3();
+    method public io.daio.wild.style.modifiers.Interactions copy(boolean focused, boolean hovered, boolean pressed);
+    method public boolean equals(Object? other);
+    method public boolean getFocused();
+    method public boolean getHovered();
+    method public boolean getPressed();
+    method public int hashCode();
+    method public String toString();
+    property public final boolean focused;
+    property public final boolean hovered;
+    property public final boolean pressed;
+  }
+
+  public final class TraversableKt {
+    method public static inline <reified T extends androidx.compose.ui.node.TraversableNode> void traverseDirectDescendants(androidx.compose.ui.node.TraversableNode, Object? key, kotlin.jvm.functions.Function1<? super T,kotlin.Unit> block);
   }
 
 }

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Border.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Border.kt
@@ -4,30 +4,15 @@ package io.daio.wild.style
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.GenericShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.ContentDrawScope
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.inset
-import androidx.compose.ui.node.DrawModifierNode
-import androidx.compose.ui.node.ModifierNodeElement
-import androidx.compose.ui.node.requireDensity
-import androidx.compose.ui.platform.InspectorInfo
-import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isUnspecified
 
 @Immutable
 data class Border(
@@ -97,218 +82,15 @@ data class Borders(
     }
 }
 
-fun Modifier.border(border: Border) = then(Modifier.border(border.shape, border.width, border.borderStroke, border.inset))
-
-fun Modifier.border(
-    shape: Shape = BorderDefaults.BorderDefaultShape,
-    width: Dp = Dp.Unspecified,
-    borderStroke: BorderStroke = BorderStroke(0.dp, Color.Unspecified),
-    inset: Dp = 0.dp,
-): Modifier {
-    return then(
-        if (width.isUnspecified) {
-            Modifier
-        } else {
-            BorderElement(
-                shape = shape,
-                borderStroke = borderStroke,
-                inset = inset,
-                inspectorInfo =
-                    debugInspectorInfo {
-                        name = "border"
-                        properties["shape"] = shape
-                        properties["borderStroke"] = borderStroke
-                        properties["inset"] = inset
-                    },
-            )
-        },
-    )
-}
-
-private class BorderElement(
-    private val shape: Shape = RectangleShape,
-    private val borderStroke: BorderStroke = BorderStroke(0.dp, Color.Unspecified),
-    private val inset: Dp = Dp.Unspecified,
-    private val inspectorInfo: InspectorInfo.() -> Unit,
-) : ModifierNodeElement<BorderNode>() {
-    override fun create(): BorderNode {
-        return BorderNode(
-            shape = shape,
-            borderStroke = borderStroke,
-            inset = inset,
-        )
-    }
-
-    override fun update(node: BorderNode) {
-        node.updateBorder(
-            newShape = shape,
-            newBorderStroke = borderStroke,
-            newInset = inset,
-        )
-    }
-
-    override fun InspectorInfo.inspectableProperties() {
-        inspectorInfo()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as BorderElement
-
-        if (shape != other.shape) return false
-        if (borderStroke != other.borderStroke) return false
-        if (inset != other.inset) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = shape.hashCode()
-        result = 31 * result + borderStroke.hashCode()
-        result = 31 * result + inset.hashCode()
-        return result
-    }
-}
-
-open class BorderNode(
-    private var shape: Shape,
-    private var borderStroke: BorderStroke,
-    private var inset: Dp,
-) : DrawModifierNode, Modifier.Node() {
-    private var shapeOutlineCache: ShapeOutlineCache? = null
-    private var outlineStrokeCache: OutlineStrokeCache? = null
-
-    fun updateBorder(
-        newShape: Shape,
-        newBorderStroke: BorderStroke,
-        newInset: Dp,
-    ) {
-        shape = newShape
-        borderStroke = newBorderStroke
-        inset = newInset
-    }
-
-    override fun ContentDrawScope.draw() {
-        drawContent()
-        drawBorder()
-    }
-
-    fun ContentDrawScope.drawBorder() {
-        if (shapeOutlineCache == null) {
-            shapeOutlineCache =
-                ShapeOutlineCache(
-                    shape = shape,
-                    size = size,
-                    layoutDirection = layoutDirection,
-                    density = this,
-                )
-        }
-
-        val borderStrokeWidthPX = with(requireDensity()) { borderStroke.width.toPx() }
-
-        if (outlineStrokeCache == null) {
-            outlineStrokeCache = OutlineStrokeCache(widthPx = borderStrokeWidthPX)
-        }
-
-        inset(inset = with(requireDensity()) { -inset.toPx() }) {
-            val shapeOutline =
-                shapeOutlineCache!!.updatedOutline(
-                    shape = shape,
-                    size = size,
-                    layoutDirection = layoutDirection,
-                    density = requireDensity(),
-                )
-
-            val outlineStroke =
-                outlineStrokeCache!!.updatedOutlineStroke(widthPx = borderStrokeWidthPX)
-
-            drawOutline(
-                outline = shapeOutline,
-                brush = borderStroke.brush,
-                alpha = 1f,
-                style = outlineStroke,
-            )
-        }
-    }
-}
-
-/** Caches the outline stroke across re-compositions */
-private class OutlineStrokeCache(private var widthPx: Float) {
-    private var outlineStroke: Stroke? = null
-
-    /**
-     * If there are updates to the arguments, creates a new outline stroke based on the updated
-     * values, else, returns the cached value
-     */
-    fun updatedOutlineStroke(widthPx: Float): Stroke {
-        if (outlineStroke == null || this.widthPx != widthPx) {
-            this.widthPx = widthPx
-            createOutlineStroke()
-        }
-        return outlineStroke!!
-    }
-
-    private fun createOutlineStroke() {
-        outlineStroke = Stroke(width = widthPx, cap = StrokeCap.Round)
-    }
-}
-
-internal class ShapeOutlineCache(
-    private var shape: Shape,
-    private var size: Size,
-    private var layoutDirection: LayoutDirection,
-    private var density: Density,
-) {
-    private var outline: Outline? = null
-
-    /**
-     * If there are updates to the arguments, creates a new outline based on the updated values,
-     * else, returns the cached value
-     */
-    fun updatedOutline(
-        shape: Shape,
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density,
-    ): Outline {
-        if (outline == null || hasUpdates(shape, size, layoutDirection, density)) {
-            syncUpdates(shape, size, layoutDirection, density)
-            createNewOutline()
-        }
-        return outline!!
-    }
-
-    private fun createNewOutline() {
-        outline =
-            shape.createOutline(size = size, layoutDirection = layoutDirection, density = density)
-    }
-
-    private fun syncUpdates(
-        shape: Shape,
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density,
-    ) {
-        this.shape = shape
-        this.size = size
-        this.layoutDirection = layoutDirection
-        this.density = density
-    }
-
-    private fun hasUpdates(
-        shape: Shape,
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density,
-    ): Boolean {
-        return when {
-            shape != this.shape -> true
-            size != this.size -> true
-            layoutDirection != this.layoutDirection -> true
-            density != this.density -> true
-            else -> false
-        }
+/**
+ * Ensures the border shape takes into account the inner shape when applying an inset.
+ */
+internal fun Border.forInnerShape(innerShape: Shape): Shape {
+    // If the Border shapes is using the default we want to follow the innerShape as out outline.
+    val borderShape = if (shape == BorderDefaults.BorderDefaultShape) innerShape else shape
+    return if (inset > 0.dp && innerShape is RoundedCornerShape && borderShape is RoundedCornerShape) {
+        borderShape.toExpandedCornerShape(inset)
+    } else {
+        borderShape
     }
 }

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Clickable.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Clickable.kt
@@ -15,7 +15,7 @@ import io.daio.wild.modifier.thenIfNotNull
  * Interop Modifier to support either [Modifier.selectable] or [Modifier.clickable], applying
  * the correct modifier based on the requirement for hardware input. For example if a Tv device
  * is detected it adds support for hardware clicks from remote controls. This has the added support
- * for [Style], applying [interactionStyle] to update the component based on the current
+ * for [Style], applying [experimentalInteractionStyle] to update the component based on the current
  * [InteractionSource] state.
  *
  * @param enabled Whether the click action handling is enabled.
@@ -65,7 +65,7 @@ fun Modifier.interactable(
  * Interop Modifier to support either [Modifier.selectable] or [Modifier.clickable], applying
  * the correct modifier based on the requirement for hardware input. For example if a Tv device
  * is detected it adds support for hardware clicks from remote controls. This has the added support
- * for [Style], applying [interactionStyle] to update the component based on the current
+ * for [Style], applying [experimentalInteractionStyle] to update the component based on the current
  * [InteractionSource] state.
  *
  * @param enabled Whether the click action handling is enabled.
@@ -78,9 +78,9 @@ fun Modifier.interactable(
  * @param onLongClick Optional callback to handle long click events.
  * @param onClick Callback when the element is clicked.
  *
- * @since 0.3.4
+ * @since 0.4.0
  */
-fun Modifier.interactable(
+fun Modifier.experimentalInteractable(
     enabled: Boolean = true,
     selected: Boolean? = null,
     style: (StyleScope.() -> Unit)? = null,
@@ -91,7 +91,7 @@ fun Modifier.interactable(
 ): Modifier =
     this then
         if (selected != null) {
-            Modifier.selectable(
+            Modifier.experimentalSelectable(
                 selected = selected,
                 style = style,
                 enabled = enabled,
@@ -101,7 +101,57 @@ fun Modifier.interactable(
                 onClick = onClick,
             )
         } else {
-            Modifier.clickable(
+            Modifier.experimentalClickable(
+                enabled = enabled,
+                style = style,
+                interactionSource = interactionSource,
+                role = role,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            )
+        }
+
+/**
+ * Interop Modifier to support either [Modifier.selectable] or [Modifier.clickable], applying
+ * the correct modifier based on the requirement for hardware input. For example if a Tv device
+ * is detected it adds support for hardware clicks from remote controls. This has the added support
+ * for [Style], applying [experimentalInteractionStyle] to update the component based on the current
+ * [InteractionSource] state.
+ *
+ * @param enabled Whether the click action handling is enabled.
+ * @param selected Optional property to set the selected state. Setting this to a value will enable
+ * selectable support.
+ * @param style Optional [Style] to apply with the interactable.
+ * @param interactionSource The interaction source to emit interaction events to.
+ * @param role The Role of the associated user interface element, typically used by Accessiblity
+ * services.
+ * @param onLongClick Optional callback to handle long click events.
+ * @param onClick Callback when the element is clicked.
+ *
+ * @since 0.4.0
+ */
+fun Modifier.experimentalInteractable(
+    enabled: Boolean = true,
+    selected: Boolean? = null,
+    style: Style? = null,
+    interactionSource: MutableInteractionSource? = null,
+    role: Role? = null,
+    onLongClick: (() -> Unit)? = null,
+    onClick: (() -> Unit),
+): Modifier =
+    this then
+        if (selected != null) {
+            Modifier.experimentalSelectable(
+                selected = selected,
+                style = style,
+                enabled = enabled,
+                interactionSource = interactionSource,
+                role = role,
+                onLongClick = onLongClick,
+                onClick = onClick,
+            )
+        } else {
+            Modifier.experimentalClickable(
                 enabled = enabled,
                 style = style,
                 interactionSource = interactionSource,
@@ -155,7 +205,48 @@ fun Modifier.clickable(
 /**
  * Interop Modifier.clickable to apply the correct clickable modifier based on the requirement for
  * hardware input. For example if a Tv device is detected it adds support for hardware clicks from
- * remote controls. This has the added support for [Style], applying [interactionStyle] to update
+ * remote controls. This has the added support for [Style], applying [experimentalInteractionStyle] to update
+ * the component based on the current [InteractionSource] state.
+ *
+ * @param enabled Whether the click action handling is enabled.
+ * @param interactionSource The interaction source to emit interaction events to.
+ * @param style Optional [Style] to apply with the clickable.
+ * @param role The Role of the associated user interface element, typically used by Accessiblity
+ * services.
+ * @param onLongClick Optional callback to handle long click events.
+ * @param onClick Callback when the element is clicked.
+ *
+ * @since 0.4.0
+ */
+fun Modifier.experimentalClickable(
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+    style: Style? = null,
+    role: Role? = null,
+    onLongClick: (() -> Unit)? = null,
+    onClick: (() -> Unit),
+) = composed {
+    @Suppress("NAME_SHADOWING")
+    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    Modifier.clickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+    ).thenIfNotNull(
+        style,
+        ifNotNullModifier = {
+            Modifier.experimentalInteractionStyle(interactionSource, enabled, style = it)
+        },
+    )
+}
+
+/**
+ * Interop Modifier.clickable to apply the correct clickable modifier based on the requirement for
+ * hardware input. For example if a Tv device is detected it adds support for hardware clicks from
+ * remote controls. This has the added support for [Style], applying [experimentalInteractionStyle] to update
  * the component based on the current [InteractionSource] state.
  *
  * @param enabled Whether the click action handling is enabled.
@@ -166,9 +257,9 @@ fun Modifier.clickable(
  * @param onLongClick Optional callback to handle long click events.
  * @param onClick Callback when the element is clicked.
  *
- * @since 0.3.4
+ * @since 0.4.0
  */
-fun Modifier.clickable(
+fun Modifier.experimentalClickable(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
     style: (StyleScope.() -> Unit)? = null,
@@ -188,7 +279,7 @@ fun Modifier.clickable(
     ).thenIfNotNull(
         style,
         ifNotNullModifier = {
-            Modifier.interactionStyle(interactionSource, enabled, block = it)
+            Modifier.experimentalInteractionStyle(interactionSource, enabled, block = it)
         },
     )
 }
@@ -196,7 +287,7 @@ fun Modifier.clickable(
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
  * hardware input. For example if a Tv device is detected it adds support for hardware clicks from
- * remote controls. This has the added support for [Style], applying [interactionStyle] to update
+ * remote controls. This has the added support for [Style], applying [experimentalInteractionStyle] to update
  *  * the component based on the current [InteractionSource] state.
  *
  * @param selected Whether the element is currently selected.
@@ -244,7 +335,55 @@ fun Modifier.selectable(
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
  * hardware input. For example if a Tv device is detected it adds support for hardware clicks from
- * remote controls. This has the added support for [Style], applying [interactionStyle] to update
+ * remote controls. This has the added support for [Style], applying [experimentalInteractionStyle] to update
+ *  * the component based on the current [InteractionSource] state.
+ *
+ * @param selected Whether the element is currently selected.
+ * @param enabled Whether the click action handling is enabled.
+ * @param interactionSource The interaction source to emit interaction events to.
+ * @param style Optional [Style] to apply with the selectable.
+ * @param role The Role of the associated user interface element, typically used by Accessiblity
+ * services.
+ * @param onClick Callback when the element is clicked.
+ *
+ * @since 0.4.0
+ */
+fun Modifier.experimentalSelectable(
+    selected: Boolean,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+    style: Style? = null,
+    role: Role? = null,
+    onLongClick: (() -> Unit)? = null,
+    onClick: (() -> Unit),
+) = composed {
+    @Suppress("NAME_SHADOWING")
+    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    Modifier.selectable(
+        selected = selected,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onLongClick = onLongClick,
+        role = role,
+        onClick = onClick,
+    ).thenIfNotNull(
+        value = style,
+        ifNotNullModifier = {
+            Modifier.experimentalInteractionStyle(
+                style = it,
+                interactionSource = interactionSource,
+                enabled = enabled,
+                selected = selected,
+            )
+        },
+    )
+}
+
+/**
+ * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
+ * hardware input. For example if a Tv device is detected it adds support for hardware clicks from
+ * remote controls. This has the added support for [Style], applying [experimentalInteractionStyle] to update
  *  * the component based on the current [InteractionSource] state.
  *
  * @param selected Whether the element is currently selected.
@@ -255,9 +394,9 @@ fun Modifier.selectable(
  * services.
  * @param onClick Callback when the element is clicked.
  *
- * @since 0.3.4
+ * @since 0.4.0
  */
-fun Modifier.selectable(
+fun Modifier.experimentalSelectable(
     selected: Boolean,
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource? = null,
@@ -279,7 +418,7 @@ fun Modifier.selectable(
     ).thenIfNotNull(
         value = style,
         ifNotNullModifier = {
-            Modifier.interactionStyle(
+            Modifier.experimentalInteractionStyle(
                 block = it,
                 interactionSource = interactionSource,
                 enabled = enabled,

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Scale.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Scale.kt
@@ -98,7 +98,16 @@ fun animateInteractionScaleAsState(
     )
 }
 
-private fun defaultScaleAnimationSpec(
+/**
+ * Creates a [TweenSpec] configured with the default duration, delay and easing curve for the state
+ * [pressed], [focused] && [hovered].
+ *
+ * @param pressed whether the element is currently pressed.
+ * @param focused whether the element is currently focused.
+ * @param hovered whether the element is currently hovered.
+ */
+@Stable
+internal fun defaultScaleAnimationSpec(
     pressed: Boolean,
     focused: Boolean,
     hovered: Boolean,

--- a/style/src/commonMain/kotlin/io/daio/wild/style/StyleScope.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/StyleScope.kt
@@ -42,7 +42,7 @@ interface StyleScope : InteractionState {
     var border: Border
 }
 
-internal class StyleScopeImpl : StyleScope {
+internal class DefaultStyleScope : StyleScope {
     override var color: Color = Color.Unspecified
     override var alpha: Float = 1f
     override var scale: Float = 1f
@@ -88,7 +88,7 @@ internal class StyleScopeImpl : StyleScope {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
 
-        other as StyleScopeImpl
+        other as DefaultStyleScope
 
         if (alpha != other.alpha) return false
         if (scale != other.scale) return false

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/BackgroundElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/BackgroundElement.kt
@@ -1,0 +1,161 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.observeReads
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.LayoutDirection
+import io.daio.wild.style.StyleScope
+
+/**
+ * Applies the background color to the element as part of the [StyleScopeParentNode].
+ */
+internal class BackgroundElement(
+    private val color: Color = Color.Unspecified,
+    private val brush: Brush? = null,
+    private val alpha: Float = 1f,
+    private val shape: Shape = RectangleShape,
+) : ModifierNodeElement<BackgroundNode>() {
+    override fun create(): BackgroundNode =
+        BackgroundNode(
+            brush = brush,
+            alpha = alpha,
+            color = color,
+            shape = shape,
+        )
+
+    override fun update(node: BackgroundNode) {
+        node.brush = brush
+        node.alpha = alpha
+        node.updateBackground(color = color, shape = shape)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "BackgroundElement"
+        properties["color"] = color
+        properties["alpha"] = alpha
+        properties["brush"] = brush
+        properties["shape"] = shape
+    }
+
+    override fun hashCode(): Int {
+        var result = color.hashCode()
+        result = 31 * result + (brush?.hashCode() ?: 0)
+        result = 31 * result + alpha.hashCode()
+        result = 31 * result + shape.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        val otherModifier = other as? BackgroundElement ?: return false
+        return color == otherModifier.color &&
+            brush == otherModifier.brush &&
+            alpha == otherModifier.alpha &&
+            shape == otherModifier.shape
+    }
+}
+
+internal class BackgroundNode(
+    var brush: Brush?,
+    var alpha: Float,
+    private var color: Color,
+    private var shape: Shape,
+) : DrawModifierNode, Modifier.Node(), ObserverModifierNode, StyleScopeChildNode {
+    // Naively cache outline calculation if input parameters are the same, we manually observe
+    // reads inside shape#createOutline separately
+    private var lastSize: Size = Size.Unspecified
+    private var lastLayoutDirection: LayoutDirection? = null
+    private var lastOutline: Outline? = null
+    private var lastShape: Shape? = null
+
+    /**
+     * Invalidation is handled by [updateBackground]
+     */
+    override val shouldAutoInvalidate: Boolean
+        get() = false
+
+    fun updateBackground(
+        color: Color,
+        shape: Shape,
+    ) {
+        if (this.color != color || this.shape != shape) {
+            this.color = color
+            this.shape = shape
+            invalidateDraw()
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        if (shape === RectangleShape) {
+            // shortcut to avoid Outline calculation and allocation
+            drawRect()
+        } else {
+            drawOutline()
+        }
+        drawContent()
+    }
+
+    override fun onObservedReadsChanged() {
+        // Reset cached properties
+        lastSize = Size.Unspecified
+        lastLayoutDirection = null
+        lastOutline = null
+        lastShape = null
+        // Invalidate draw so we build the cache again - this is needed because observeReads within
+        // the draw scope obscures the state reads from the draw scope's observer
+        invalidateDraw()
+    }
+
+    private fun ContentDrawScope.drawRect() {
+        if (color.isSpecified) {
+            drawRect(color = color)
+        }
+        brush?.let { drawRect(brush = it, alpha = alpha) }
+    }
+
+    private fun ContentDrawScope.drawOutline() {
+        val outline = getOutline()
+        if (color.isSpecified) {
+            drawOutline(outline, color = color)
+        }
+        brush?.let { drawOutline(outline, brush = it, alpha = alpha) }
+    }
+
+    private fun ContentDrawScope.getOutline(): Outline {
+        var outline: Outline? = null
+        if (size == lastSize && layoutDirection == lastLayoutDirection && lastShape == shape) {
+            outline = lastOutline!!
+        } else {
+            // Manually observe reads so we can directly invalidate the outline when it changes
+            observeReads {
+                outline = shape.createOutline(size, layoutDirection, this)
+            }
+        }
+        lastOutline = outline
+        lastSize = size
+        lastLayoutDirection = layoutDirection
+        lastShape = shape
+        return outline!!
+    }
+
+    override fun updateStyle(styleScope: StyleScope) {
+        updateBackground(
+            color = styleScope.color,
+            shape = styleScope.shape,
+        )
+    }
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/BorderElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/BorderElement.kt
@@ -1,0 +1,257 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.inset
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireDensity
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isUnspecified
+import io.daio.wild.style.Border
+import io.daio.wild.style.BorderDefaults
+import io.daio.wild.style.StyleScope
+import io.daio.wild.style.forInnerShape
+
+/**
+ * Applies the border to the element as part of the [StyleScopeParentNode].
+ */
+internal class BorderElement(
+    private val shape: Shape = RectangleShape,
+    private val borderStroke: BorderStroke = BorderStroke(0.dp, Color.Unspecified),
+    private val inset: Dp = 0.dp,
+) : ModifierNodeElement<BorderNode>() {
+    override fun create(): BorderNode =
+        BorderNode(
+            shape = shape,
+            borderStroke = borderStroke,
+            inset = inset,
+        )
+
+    override fun update(node: BorderNode) {
+        node.updateBorder(shape = shape, borderStroke = borderStroke, inset = inset)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "BorderElement"
+        properties["shape"] = shape
+        properties["borderStroke"] = borderStroke
+        properties["inset"] = inset
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BorderElement
+
+        if (shape != other.shape) return false
+        if (borderStroke != other.borderStroke) return false
+        if (inset != other.inset) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = shape.hashCode()
+        result = 31 * result + borderStroke.hashCode()
+        result = 31 * result + inset.hashCode()
+        return result
+    }
+}
+
+internal class BorderNode(
+    private var shape: Shape,
+    private var borderStroke: BorderStroke,
+    private var inset: Dp,
+) : DrawModifierNode, Modifier.Node(), StyleScopeChildNode {
+    private var shapeOutlineCache: ShapeOutlineCache? = null
+    private var outlineStrokeCache: OutlineStrokeCache? = null
+
+    /**
+     * Invalidation is handled by [updateBorder]
+     */
+    override val shouldAutoInvalidate: Boolean
+        get() = false
+
+    fun updateBorder(
+        shape: Shape,
+        borderStroke: BorderStroke,
+        inset: Dp,
+    ) {
+        if (this.borderStroke != borderStroke || this.inset != inset || this.shape != shape) {
+            this.shape = shape
+            this.borderStroke = borderStroke
+            this.inset = inset
+
+            invalidateDraw()
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        drawContent()
+        drawBorder()
+    }
+
+    private fun ContentDrawScope.drawBorder() {
+        if (shapeOutlineCache == null) {
+            shapeOutlineCache =
+                ShapeOutlineCache(
+                    shape = shape,
+                    size = size,
+                    layoutDirection = layoutDirection,
+                    density = this,
+                )
+        }
+
+        val borderStrokeWidthPX = with(requireDensity()) { borderStroke.width.toPx() }
+
+        if (outlineStrokeCache == null) {
+            outlineStrokeCache = OutlineStrokeCache(widthPx = borderStrokeWidthPX)
+        }
+
+        inset(inset = with(requireDensity()) { -inset.toPx() }) {
+            val shapeOutline =
+                shapeOutlineCache!!.updatedOutline(
+                    shape = shape,
+                    size = size,
+                    layoutDirection = layoutDirection,
+                    density = requireDensity(),
+                )
+
+            val outlineStroke =
+                outlineStrokeCache!!.updatedOutlineStroke(widthPx = borderStrokeWidthPX)
+
+            drawOutline(
+                outline = shapeOutline,
+                brush = borderStroke.brush,
+                alpha = 1f,
+                style = outlineStroke,
+            )
+        }
+    }
+
+    override fun updateStyle(styleScope: StyleScope) {
+        updateBorder(
+            shape = styleScope.border.forInnerShape(styleScope.shape),
+            borderStroke = styleScope.border.borderStroke,
+            inset = styleScope.border.inset,
+        )
+    }
+}
+
+/** Caches the outline stroke across re-compositions */
+private class OutlineStrokeCache(private var widthPx: Float) {
+    private var outlineStroke: Stroke? = null
+
+    /**
+     * If there are updates to the arguments, creates a new outline stroke based on the updated
+     * values, else, returns the cached value
+     */
+    fun updatedOutlineStroke(widthPx: Float): Stroke {
+        if (outlineStroke == null || this.widthPx != widthPx) {
+            this.widthPx = widthPx
+            createOutlineStroke()
+        }
+        return outlineStroke!!
+    }
+
+    private fun createOutlineStroke() {
+        outlineStroke = Stroke(width = widthPx, cap = StrokeCap.Round)
+    }
+}
+
+internal class ShapeOutlineCache(
+    private var shape: Shape,
+    private var size: Size,
+    private var layoutDirection: LayoutDirection,
+    private var density: Density,
+) {
+    private var outline: Outline? = null
+
+    /**
+     * If there are updates to the arguments, creates a new outline based on the updated values,
+     * else, returns the cached value
+     */
+    fun updatedOutline(
+        shape: Shape,
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline {
+        if (outline == null || hasUpdates(shape, size, layoutDirection, density)) {
+            syncUpdates(shape, size, layoutDirection, density)
+            createNewOutline()
+        }
+        return outline!!
+    }
+
+    private fun createNewOutline() {
+        outline =
+            shape.createOutline(size = size, layoutDirection = layoutDirection, density = density)
+    }
+
+    private fun syncUpdates(
+        shape: Shape,
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ) {
+        this.shape = shape
+        this.size = size
+        this.layoutDirection = layoutDirection
+        this.density = density
+    }
+
+    private fun hasUpdates(
+        shape: Shape,
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Boolean {
+        return when {
+            shape != this.shape -> true
+            size != this.size -> true
+            layoutDirection != this.layoutDirection -> true
+            density != this.density -> true
+            else -> false
+        }
+    }
+}
+
+fun Modifier.border(border: Border) = then(Modifier.border(border.shape, border.width, border.borderStroke, border.inset))
+
+fun Modifier.border(
+    shape: Shape = BorderDefaults.BorderDefaultShape,
+    width: Dp = Dp.Unspecified,
+    borderStroke: BorderStroke = BorderStroke(0.dp, Color.Unspecified),
+    inset: Dp = 0.dp,
+): Modifier {
+    return then(
+        if (width.isUnspecified) {
+            Modifier
+        } else {
+            BorderElement(
+                shape = shape,
+                borderStroke = borderStroke,
+                inset = inset,
+            )
+        },
+    )
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
@@ -1,0 +1,166 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.TraversableNode
+import androidx.compose.ui.platform.InspectorInfo
+import io.daio.wild.foundation.ExperimentalWildApi
+import kotlinx.coroutines.launch
+
+/**
+ * Modifier to attach an [InteractionSource] to an element allowing child traversable Nodes to
+ * listen to interactions by implementing [InteractionSourceObserverNode].
+ *
+ * A child element implementing [InteractionSourceObserverNode] should override
+ * onInteractionsChanged to respond to interaction source changes.
+ *
+ * @param interactionSource The [InteractionSource] to associate with a Node.
+ * @param childTraversalKey The traversal key used to find the [InteractionSourceObserverNode].
+ *
+ * @since 0.4.0
+ */
+@ExperimentalWildApi
+fun Modifier.interactionSourceNode(
+    interactionSource: InteractionSource?,
+    childTraversalKey: Any = DefaultInteractionSourceChildTraversalKey,
+): Modifier = this then InteractionSourceElement(interactionSource, childTraversalKey)
+
+object DefaultInteractionSourceChildTraversalKey
+
+@Immutable
+data class Interactions(
+    val focused: Boolean,
+    val hovered: Boolean,
+    val pressed: Boolean,
+)
+
+/**
+ * Observe [InteractionSource] updated for a node within a direct child of
+ * [InteractionSourceElement] nodes.
+ */
+interface InteractionSourceObserverNode : TraversableNode {
+    /**
+     * Called when any interaction such as focused, pressed or hovered changes state on the parent
+     * node.
+     */
+    fun onInteractionStateChanged(interactions: Interactions)
+}
+
+internal class InteractionSourceElement(
+    val interactionSource: InteractionSource?,
+    val childTraversalKey: Any = DefaultInteractionSourceChildTraversalKey,
+) : ModifierNodeElement<InteractionSourceNode>() {
+    override fun create() =
+        InteractionSourceNode(
+            interactionSource = interactionSource,
+            childTraversalKey = childTraversalKey,
+        )
+
+    override fun update(node: InteractionSourceNode) {
+        node.interactionSource = interactionSource
+        node.childTraversalKey = childTraversalKey
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "InteractionSourceElement"
+        properties["interactionSource"] = interactionSource
+        properties["childTraversalKey"] = childTraversalKey
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as InteractionSourceElement
+
+        if (interactionSource != other.interactionSource) return false
+        if (childTraversalKey != other.childTraversalKey) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = interactionSource.hashCode()
+        result = 31 * result + childTraversalKey.hashCode()
+        return result
+    }
+}
+
+internal class InteractionSourceNode(
+    var interactionSource: InteractionSource?,
+    var childTraversalKey: Any,
+) : Modifier.Node(), TraversableNode {
+    var focused: Boolean = false
+        internal set
+
+    var hovered: Boolean = false
+        internal set
+
+    var pressed: Boolean = false
+        internal set
+
+    var enabled: Boolean = false
+        internal set
+
+    var selected: Boolean = false
+        internal set
+
+    override fun onAttach() {
+        coroutineScope.launch {
+            interactionSource?.interactions?.collect { interaction ->
+                when (interaction) {
+                    is PressInteraction.Press -> pressed = true
+                    is PressInteraction.Release -> pressed = false
+                    is PressInteraction.Cancel -> pressed = false
+                    is HoverInteraction.Enter -> hovered = true
+                    is HoverInteraction.Exit -> hovered = false
+                    is FocusInteraction.Focus -> focused = true
+                    is FocusInteraction.Unfocus -> focused = false
+                }
+
+                notifyInteractionsChanged(
+                    Interactions(
+                        focused = focused,
+                        hovered = hovered,
+                        pressed = pressed,
+                    ),
+                )
+            }
+        }
+    }
+
+    override fun onDetach() {
+        reset()
+    }
+
+    private fun reset() {
+        hovered = false
+        focused = false
+        pressed = false
+        notifyInteractionsChanged(
+            Interactions(
+                focused = focused,
+                hovered = hovered,
+                pressed = pressed,
+            ),
+        )
+    }
+
+    private fun notifyInteractionsChanged(interactions: Interactions) {
+        traverseDirectDescendants<InteractionSourceObserverNode>(childTraversalKey) {
+            it.onInteractionStateChanged(interactions)
+        }
+    }
+
+    private companion object InteractionSourceParentKey
+
+    override val traverseKey: Any
+        get() = InteractionSourceParentKey
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -1,0 +1,149 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.animateTo
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.findNearestAncestor
+import androidx.compose.ui.node.invalidatePlacement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Constraints
+import io.daio.wild.style.StyleScope
+import io.daio.wild.style.defaultScaleAnimationSpec
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+
+/**
+ * Applies the scale to the element as part of the [StyleScopeParentNode].
+ */
+internal class ScaleLayoutElement(
+    val zIndex: Float = 0f,
+    val scale: Float = 1f,
+) : ModifierNodeElement<ScaleLayoutModifier>() {
+    override fun create() = ScaleLayoutModifier(zIndex = zIndex, scale = scale)
+
+    override fun update(node: ScaleLayoutModifier) {
+        node.updateScale(scale = scale, zIndex = zIndex)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "ScaleLayoutElement"
+        properties["scale"] = scale
+        properties["zIndex"] = zIndex
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ScaleLayoutElement
+
+        if (zIndex != other.zIndex) return false
+        if (scale != other.scale) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = zIndex.hashCode()
+        result = 31 * result + scale.hashCode()
+        return result
+    }
+}
+
+internal class ScaleLayoutModifier(
+    var zIndex: Float,
+    var scale: Float,
+) : LayoutModifierNode,
+    Modifier.Node(),
+    StyleScopeChildNode {
+    private val zIndexState = AnimationState(initialValue = zIndex)
+    private val scaleState = AnimationState(initialValue = scale)
+
+    /**
+     * Invalidation is handled by [updateScale]
+     */
+    override val shouldAutoInvalidate: Boolean
+        get() = false
+
+    fun updateScale(
+        scale: Float,
+        zIndex: Float,
+    ) {
+        if (!isAttached) {
+            return
+        }
+
+        val parent =
+            findNearestAncestor(StyleParentTraversalKey) as? StyleScopeParentNode ?: return
+
+        updateScale(
+            scale = scale,
+            zIndex = zIndex,
+            focused = parent.focused,
+            pressed = parent.pressed,
+            hovered = parent.hovered,
+        )
+    }
+
+    private fun updateScale(
+        scale: Float,
+        zIndex: Float,
+        focused: Boolean,
+        pressed: Boolean,
+        hovered: Boolean,
+    ) {
+        if (scaleState.value != scale || zIndexState.value != zIndex) {
+            this.scale = scale
+            this.zIndex = zIndex
+
+            coroutineScope.launch {
+                joinAll(
+                    launch { zIndexState.animateTo(zIndex) },
+                    launch {
+                        scaleState.animateTo(
+                            targetValue = scale,
+                            animationSpec =
+                                defaultScaleAnimationSpec(
+                                    focused = focused,
+                                    pressed = pressed,
+                                    hovered = hovered,
+                                ),
+                        )
+                    },
+                )
+
+                invalidatePlacement()
+            }
+        }
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.placeWithLayer(0, 0, zIndex = zIndexState.value) {
+                scaleX = scaleState.value
+                scaleY = scaleState.value
+            }
+        }
+    }
+
+    override fun updateStyle(styleScope: StyleScope) {
+        updateScale(
+            scale = styleScope.scale,
+            zIndex = if (styleScope.focused) 0.5f else 0f,
+            focused = styleScope.focused,
+            pressed = styleScope.pressed,
+            hovered = styleScope.hovered,
+        )
+    }
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ShapeLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ShapeLayoutElement.kt
@@ -1,0 +1,101 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidatePlacement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Constraints
+import io.daio.wild.style.StyleScope
+
+/**
+ * Applies the main [Shape] to the element as part of the [StyleScopeParentNode].
+ */
+internal class ShapeLayoutElement(
+    val shape: Shape = RectangleShape,
+    val alpha: Float = 1f,
+) : ModifierNodeElement<ShapeLayoutModifier>() {
+    override fun create() = ShapeLayoutModifier(shape = shape, alpha = alpha)
+
+    override fun update(node: ShapeLayoutModifier) {
+        node.updateShape(shape = shape, alpha = alpha)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "ShapeLayoutElement"
+        properties["shape"] = shape
+        properties["alpha"] = alpha
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ShapeLayoutElement
+
+        if (alpha != other.alpha) return false
+        if (shape != other.shape) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = alpha.hashCode()
+        result = 31 * result + shape.hashCode()
+        return result
+    }
+}
+
+internal class ShapeLayoutModifier(
+    var shape: Shape,
+    var alpha: Float,
+) : LayoutModifierNode,
+    Modifier.Node(),
+    StyleScopeChildNode {
+    /**
+     * Invalidation is handled by [updateShape]
+     */
+    override val shouldAutoInvalidate: Boolean
+        get() = false
+
+    fun updateShape(
+        shape: Shape,
+        alpha: Float,
+    ) {
+        if (this.shape != shape || this.alpha != alpha) {
+            this.shape = shape
+            this.alpha = alpha
+            invalidatePlacement()
+        }
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.placeWithLayer(0, 0) {
+                alpha = this@ShapeLayoutModifier.alpha
+                shape = this@ShapeLayoutModifier.shape
+                clip = true
+                compositingStrategy = CompositingStrategy.Offscreen
+            }
+        }
+    }
+
+    override fun updateStyle(styleScope: StyleScope) {
+        updateShape(
+            shape = styleScope.shape,
+            alpha = styleScope.alpha,
+        )
+    }
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/StyleScopeChildNode.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/StyleScopeChildNode.kt
@@ -1,0 +1,35 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.ui.node.TraversableNode
+import io.daio.wild.style.StyleScope
+
+/**
+ * Default traversal key for [StyleScopeChildNode] traversable nodes.
+ */
+internal object StyleChildTraversalKey
+
+/**
+ * Default traversal key for [StyleScopeParentNode] traversable nodes.
+ */
+internal object StyleParentTraversalKey
+
+/**
+ * Interface to mark a Node as a child in order to apply styles in response to [StyleScope] changes
+ * from [StyleScopeParentNode].
+ */
+internal interface StyleScopeChildNode : TraversableNode {
+    /**
+     * Called when styles have been updated.
+     *
+     * @param styleScope The scope of the changes including states.
+     */
+    fun updateStyle(styleScope: StyleScope)
+
+    /**
+     * Traverse key used by [StyleScopeParentNode] to locate this node as a child.
+     */
+    override val traverseKey: Any
+        get() = StyleChildTraversalKey
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/StyleScopeParentElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/StyleScopeParentElement.kt
@@ -1,0 +1,126 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.TraversableNode
+import androidx.compose.ui.platform.InspectorInfo
+import io.daio.wild.style.Border
+import io.daio.wild.style.BorderDefaults
+import io.daio.wild.style.StyleScope
+
+internal class StyleScopeParentElement(
+    val enabled: Boolean = true,
+    val selected: Boolean = false,
+    val block: StyleScope.() -> Unit,
+) : ModifierNodeElement<StyleScopeParentNode>() {
+    override fun create() = StyleScopeParentNode(block = block)
+
+    override fun update(node: StyleScopeParentNode) {
+        node.updateState(selected = selected, enabled = enabled, block = block)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "StyleScopeParentElement"
+        properties["block"] = block
+        properties["enabled"] = enabled
+        properties["selected"] = selected
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StyleScopeParentElement
+
+        if (enabled != other.enabled) return false
+        if (selected != other.selected) return false
+        if (block != other.block) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = enabled.hashCode()
+        result = 31 * result + selected.hashCode()
+        result = 31 * result + block.hashCode()
+        return result
+    }
+}
+
+internal class StyleScopeParentNode(
+    var block: StyleScope.() -> Unit,
+) : StyleScope,
+    TraversableNode,
+    InteractionSourceObserverNode,
+    Modifier.Node() {
+    override var color: Color = Color.Unspecified
+    override var alpha: Float = 1f
+    override var scale: Float = 1f
+    override var shape: Shape = RectangleShape
+    override var border: Border = BorderDefaults.None
+
+    override val focused: Boolean
+        get() = _focused
+
+    override val hovered: Boolean
+        get() = _hovered
+
+    override val pressed: Boolean
+        get() = _pressed
+
+    override val selected: Boolean
+        get() = _selected
+
+    override val enabled: Boolean
+        get() = _enabled
+
+    private var _enabled: Boolean = true
+    private var _focused: Boolean = false
+    private var _hovered: Boolean = false
+    private var _pressed: Boolean = false
+    private var _selected: Boolean = false
+
+    fun updateState(
+        selected: Boolean,
+        enabled: Boolean,
+        block: StyleScope.() -> Unit,
+    ) {
+        if (_enabled != enabled || _selected != selected || this.block != block) {
+            _enabled = enabled
+            _selected = selected
+            this.block = block
+            updateStyle()
+        }
+    }
+
+    override fun onAttach() {
+        updateStyle()
+    }
+
+    private fun updateStyle() {
+        block.invoke(this)
+
+        traverseDirectDescendants<StyleScopeChildNode>(key = StyleChildTraversalKey) {
+            it.updateStyle(this)
+        }
+    }
+
+    override fun onInteractionStateChanged(interactions: Interactions) {
+        if (_focused != interactions.focused ||
+            _pressed != interactions.pressed ||
+            _hovered != interactions.hovered
+        ) {
+            _focused = interactions.focused
+            _pressed = interactions.pressed
+            _hovered = interactions.hovered
+            updateStyle()
+        }
+    }
+
+    override val traverseKey: Any = StyleParentTraversalKey
+}

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/Traversable.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/Traversable.kt
@@ -1,0 +1,27 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.ui.node.TraversableNode
+import androidx.compose.ui.node.findNearestAncestor
+import androidx.compose.ui.node.traverseDescendants
+
+/**
+ * Executes [block] for each direct descendant of this TraversableNode with a matching [key].
+ *
+ * @param key Traversal key of the descendants.
+ * @param block Callback for all matching descendants.
+ * @since 0.4.0
+ */
+inline fun <reified T : TraversableNode> TraversableNode.traverseDirectDescendants(
+    key: Any?,
+    noinline block: (T) -> Unit,
+) {
+    traverseDescendants(key) { node ->
+        if (node.node.isAttached && node is T && node.findNearestAncestor(traverseKey) === this) {
+            block(node)
+            return@traverseDescendants TraversableNode.Companion.TraverseDescendantsAction.ContinueTraversal
+        }
+        TraversableNode.Companion.TraverseDescendantsAction.CancelTraversal
+    }
+}


### PR DESCRIPTION
Follow on from a previous experiment to traverse nodes for styling

This MR separates the work so that the experiment can continue under experimentalModifiers leaving the current API the same.

## Overview
This MR introduces a new approach to styling in the Wild library using custom Node implementations for modifiers. The implementation provides performance improvements, particularly in frame duration consistency and handling of edge cases. This work is part of our ongoing effort to optimize the Wild library for different platforms and use cases.

## Changes

### Added
- New modifier elements in the `style/modifiers` package:
  - `BackgroundElement.kt`: Optimized background drawing with caching
  - `BorderElement.kt`: Custom border implementation
  - `InteractionSourceElement.kt`: Handling of interaction states
  - `ScaleLayoutElement.kt`: Optimized scaling implementation
  - `ShapeLayoutElement.kt`: Shape handling
  - `StyleScopeChildNode.kt`: Child node interface
  - `StyleScopeParentElement.kt`: Parent element for style coordination
  - `Traversable.kt`: Node traversal utilities

### Modified
- Updated API files to reflect new implementations
- Enhanced TV playbook app to support benchmarking different implementations
- Added benchmark tests to measure performance of different styling approaches

## Purpose
The primary goal of these changes is to improve performance for TV applications by:
1. Reducing frame duration variability (jank)
2. Optimizing worst-case scenarios (P95, P99 percentiles)
3. Providing a more consistent user experience during complex interactions

## Performance Impact
Based on benchmark results:

| Implementation | Frame Count | P50 (ms) | P90 (ms) | P95 (ms) | P99 (ms) | Run Time (s) |
|----------------|------------|----------|----------|----------|----------|--------------|
| Wild Experimental Modifier | 131.5 | **11.45** | 17.13 | **21.58** | **31.44** | 42.27 |
| Wild Container | 132.0 | 13.02 | 19.19 | 30.22 | 38.97 | 39.80 |
| Wild Composed Modifier | 131.0 | 12.10 | **16.99** | 24.78 | 33.02 | **39.59** |
| Material Surface | **141.0** | 13.43 | 21.63 | 29.80 | 42.86 | 39.92 |

Key improvements over Material Surface:
- 14.7% improvement in median frame duration (P50)
- 20.8% improvement in P90 frame duration
- 27.6% improvement in P95 frame duration
- 26.6% improvement in P99 frame duration

While the Experimental Modifier approach produces slightly fewer frames than Material Surface, it provides significantly better frame duration metrics, especially in worst-case scenarios, resulting in a smoother user experience with less jank.

## Technical Details

### Implementation Approach
The implementation uses Compose UI's low-level node API to create custom modifier nodes that:
1. Cache calculations where possible (e.g., shape outlines)
2. Use manual observation of reads for more efficient invalidation
3. Implement a parent-child relationship between style elements
4. Optimize drawing operations

### Key Optimizations
- `BackgroundNode`: Caches outline calculations and uses shortcuts for rectangle shapes
- `StyleScopeParentNode`: Efficiently propagates style changes to child nodes
- `InteractionSourceObserverNode`: Minimizes recompositions by handling interaction state changes at the node level

## Recommendations
Based on the benchmark results:

1. **For most TV applications**: Wild Experimental Modifier offers the best overall performance with excellent frame duration metrics.

2. **For performance-critical applications**: Wild Experimental Modifier is the clear choice due to its superior handling of worst-case scenarios.

3. **For simple UIs with basic interactions**: Wild Composed Modifier may be preferred due to its faster total run time.

## Next Steps
- Consider other options for the experimental approach including indications rather than modifiers
- Further benchmark and fine tune