### PR TITLE
Migrate over to using Modifier.combinedClickable and selectable

### DIFF
--- a/foundations/build.gradle.kts
+++ b/foundations/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(compose.foundation)
+                implementation(projects.modifier)
             }
         }
     }


### PR DESCRIPTION
Drafting to snapshot and test further moving away form the custom Clickable handling needed for Tv to use combinedClickable and selectable.

In the past support for this was patchy on Tv and without digging deep into clickable (yet) this looks to now work on Tv with a remote input. I have kept the focus semantics for Tv and ensured it remains focusable even when disabled to support the behaviour expected there but so far all looks to be working

_deploying snapshot to test_