### PR TITLE
feat(site): add storybook to GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Copy Kdoc Site
         run: mkdir -p ./site/reference && cp -r ./build/dokka/html/* ./site/reference
 
+      - name: Build Storybook
+        run: ./gradlew :playbook:web:wasmJsBrowserDistribution
+
+      - name: Copy Storybook Site
+        run: mkdir -p ./site/storybook && cp -r ./playbook/web/build/dist/wasmJs/productionExecutable/* ./site/storybook
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - 'Container': container.md
   - 'Button': button.md
   - 'Modifier': modifier.md
+  - 'Usage Docs': storybook/
   - 'Api Reference': reference/
 
 theme:

--- a/playbook/web/src/jsMain/resources/index.html
+++ b/playbook/web/src/jsMain/resources/index.html
@@ -7,9 +7,9 @@
     <style>
         html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }
     </style>
-    <script src="/skiko.js"></script>
+    <script src="./skiko.js"></script>
 </head>
 <body>
-<script src="/web.js"></script>
+<script src="./web.js"></script>
 </body>
 </html>

--- a/playbook/web/src/wasmJsMain/resources/index.html
+++ b/playbook/web/src/wasmJsMain/resources/index.html
@@ -9,6 +9,6 @@
     </style>
 </head>
 <body>
-<script src="/web.js"></script>
+<script src="./web.js"></script>
 </body>
 </html>

--- a/playbook/web/webpack.config.d/config.js
+++ b/playbook/web/webpack.config.d/config.js
@@ -1,5 +1,8 @@
 const TerserPlugin = require("terser-webpack-plugin");
 
+config.output = config.output || {};
+config.output.publicPath = "auto";
+
 config.optimization = config.optimization || {};
 config.optimization.minimize = true;
 config.optimization.minimizer = [


### PR DESCRIPTION
## Summary
- Adds the interactive storybook (Compose WASM) build to the `docs_deploy.yml` workflow, deployed at `/storybook/`
- Adds "Usage Docs" sidebar item in MkDocs nav linking to the storybook
- Fixes script paths in playbook web HTML to use relative paths (`./`) and sets webpack `publicPath: "auto"` so assets load correctly under the `/wild/storybook/` subdirectory

## Test plan
- [x] Trigger the Deploy Docs workflow and verify the storybook loads at `https://daio-io.github.io/wild/storybook/`
- [x] Verify "Usage Docs" appears in the MkDocs sidebar and links correctly
- [x] Verify existing docs and API reference are unaffected