### PR TITLE
Coalesce scale layout animation updates

### DIFF
--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Constraints
 import io.daio.wild.style.StyleScope
 import io.daio.wild.style.defaultScaleAnimationSpec
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -18,11 +18,8 @@ import androidx.compose.ui.unit.Constraints
 import io.daio.wild.style.StyleScope
 import io.daio.wild.style.defaultScaleAnimationSpec
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 
 /**
  * Applies the scale to the element as part of the [StyleScopeParentNode].
@@ -78,8 +75,7 @@ internal class ScaleLayoutModifier(
         get() = false
 
     private var updateJob: Job? = null
-    private var animationJob: Job? = null
-    private var pendingUpdate: ScaleAnimationUpdate? = null
+    private var lastAnimationRequest: ScaleAnimationRequest? = null
 
     override fun onAttach() {
         requestInitialStyleFromParent()
@@ -88,9 +84,7 @@ internal class ScaleLayoutModifier(
     override fun onReset() {
         updateJob?.cancel()
         updateJob = null
-        animationJob?.cancel()
-        animationJob = null
-        pendingUpdate = null
+        lastAnimationRequest = null
         scale = 1f
         zIndex = 0f
         customAnimationSpec = null
@@ -126,62 +120,43 @@ internal class ScaleLayoutModifier(
         hovered: Boolean,
         animationSpec: AnimationSpec<Float>? = customAnimationSpec,
     ) {
+        val animationRequest =
+            scaleAnimationRequest(
+                scale = scale,
+                zIndex = zIndex,
+                animationSpec = animationSpec,
+                pressed = pressed,
+            )
+
         this.scale = scale
         this.zIndex = zIndex
 
-        pendingUpdate =
-            ScaleAnimationUpdate(
-                zIndex = zIndex,
-                scale = scale,
-                focused = focused,
-                pressed = pressed,
-                hovered = hovered,
-                animationSpec = animationSpec,
-            )
+        if (animationRequest == lastAnimationRequest) return
+        lastAnimationRequest = animationRequest
 
-        if (updateJob?.isActive == true) return
-
+        updateJob?.cancel()
         updateJob =
             coroutineScope.launch {
-                yield()
-
-                while (true) {
-                    val update = pendingUpdate ?: return@launch
-                    pendingUpdate = null
-
-                    animationJob?.cancelAndJoin()
-                    animationJob =
+                try {
+                    joinAll(
+                        launch { zIndexState.animateTo(zIndex) },
                         launch {
-                            animateToUpdate(update)
-                        }
-
-                    yield()
+                            scaleState.animateTo(
+                                targetValue = scale,
+                                animationSpec =
+                                    animationSpec
+                                        ?: defaultScaleAnimationSpec(
+                                            focused = focused,
+                                            pressed = pressed,
+                                            hovered = hovered,
+                                        ),
+                            )
+                        },
+                    )
+                } finally {
+                    invalidatePlacement()
                 }
             }
-    }
-
-    private suspend fun animateToUpdate(update: ScaleAnimationUpdate) {
-        try {
-            coroutineScope {
-                joinAll(
-                    launch { zIndexState.animateTo(update.zIndex) },
-                    launch {
-                        scaleState.animateTo(
-                            targetValue = update.scale,
-                            animationSpec =
-                                update.animationSpec
-                                    ?: defaultScaleAnimationSpec(
-                                        focused = update.focused,
-                                        pressed = update.pressed,
-                                        hovered = update.hovered,
-                                    ),
-                        )
-                    },
-                )
-            }
-        } finally {
-            invalidatePlacement()
-        }
     }
 
     override fun MeasureScope.measure(
@@ -211,11 +186,38 @@ internal class ScaleLayoutModifier(
     }
 }
 
-private data class ScaleAnimationUpdate(
-    val zIndex: Float,
+internal data class ScaleAnimationRequest(
     val scale: Float,
-    val focused: Boolean,
-    val pressed: Boolean,
-    val hovered: Boolean,
-    val animationSpec: AnimationSpec<Float>?,
+    val zIndex: Float,
+    val animationSpecKey: ScaleAnimationSpecKey,
 )
+
+internal sealed interface ScaleAnimationSpecKey {
+    data class Default(val durationMillis: Int) : ScaleAnimationSpecKey
+
+    data class Custom(val animationSpec: AnimationSpec<Float>) : ScaleAnimationSpecKey
+}
+
+internal fun scaleAnimationRequest(
+    scale: Float,
+    zIndex: Float,
+    animationSpec: AnimationSpec<Float>?,
+    pressed: Boolean,
+): ScaleAnimationRequest =
+    ScaleAnimationRequest(
+        scale = scale,
+        zIndex = zIndex,
+        animationSpecKey = scaleAnimationSpecKey(animationSpec = animationSpec, pressed = pressed),
+    )
+
+internal fun scaleAnimationSpecKey(
+    animationSpec: AnimationSpec<Float>?,
+    pressed: Boolean,
+): ScaleAnimationSpecKey =
+    animationSpec?.let(ScaleAnimationSpecKey::Custom)
+        ?: ScaleAnimationSpecKey.Default(
+            durationMillis = if (pressed) DEFAULT_PRESSED_SCALE_ANIMATION_DURATION_MILLIS else DEFAULT_SCALE_ANIMATION_DURATION_MILLIS,
+        )
+
+private const val DEFAULT_SCALE_ANIMATION_DURATION_MILLIS = 300
+private const val DEFAULT_PRESSED_SCALE_ANIMATION_DURATION_MILLIS = 120

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -17,9 +17,12 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Constraints
 import io.daio.wild.style.StyleScope
 import io.daio.wild.style.defaultScaleAnimationSpec
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 /**
  * Applies the scale to the element as part of the [StyleScopeParentNode].
@@ -75,6 +78,8 @@ internal class ScaleLayoutModifier(
         get() = false
 
     private var updateJob: Job? = null
+    private var animationJob: Job? = null
+    private var pendingUpdate: ScaleAnimationUpdate? = null
 
     override fun onAttach() {
         requestInitialStyleFromParent()
@@ -83,6 +88,9 @@ internal class ScaleLayoutModifier(
     override fun onReset() {
         updateJob?.cancel()
         updateJob = null
+        animationJob?.cancel()
+        animationJob = null
+        pendingUpdate = null
         scale = 1f
         zIndex = 0f
         customAnimationSpec = null
@@ -121,29 +129,59 @@ internal class ScaleLayoutModifier(
         this.scale = scale
         this.zIndex = zIndex
 
-        updateJob?.cancel()
+        pendingUpdate =
+            ScaleAnimationUpdate(
+                zIndex = zIndex,
+                scale = scale,
+                focused = focused,
+                pressed = pressed,
+                hovered = hovered,
+                animationSpec = animationSpec,
+            )
+
+        if (updateJob?.isActive == true) return
+
         updateJob =
             coroutineScope.launch {
-                try {
-                    joinAll(
-                        launch { zIndexState.animateTo(zIndex) },
+                yield()
+
+                while (true) {
+                    val update = pendingUpdate ?: return@launch
+                    pendingUpdate = null
+
+                    animationJob?.cancelAndJoin()
+                    animationJob =
                         launch {
-                            scaleState.animateTo(
-                                targetValue = scale,
-                                animationSpec =
-                                    animationSpec
-                                        ?: defaultScaleAnimationSpec(
-                                            focused = focused,
-                                            pressed = pressed,
-                                            hovered = hovered,
-                                        ),
-                            )
-                        },
-                    )
-                } finally {
-                    invalidatePlacement()
+                            animateToUpdate(update)
+                        }
+
+                    yield()
                 }
             }
+    }
+
+    private suspend fun animateToUpdate(update: ScaleAnimationUpdate) {
+        try {
+            coroutineScope {
+                joinAll(
+                    launch { zIndexState.animateTo(update.zIndex) },
+                    launch {
+                        scaleState.animateTo(
+                            targetValue = update.scale,
+                            animationSpec =
+                                update.animationSpec
+                                    ?: defaultScaleAnimationSpec(
+                                        focused = update.focused,
+                                        pressed = update.pressed,
+                                        hovered = update.hovered,
+                                    ),
+                        )
+                    },
+                )
+            }
+        } finally {
+            invalidatePlacement()
+        }
     }
 
     override fun MeasureScope.measure(
@@ -172,3 +210,12 @@ internal class ScaleLayoutModifier(
         )
     }
 }
+
+private data class ScaleAnimationUpdate(
+    val zIndex: Float,
+    val scale: Float,
+    val focused: Boolean,
+    val pressed: Boolean,
+    val hovered: Boolean,
+    val animationSpec: AnimationSpec<Float>?,
+)

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -75,7 +75,7 @@ internal class ScaleLayoutModifier(
         get() = false
 
     private var updateJob: Job? = null
-    private var lastAnimationRequest: ScaleAnimationRequest? = null
+    private val animationRequestCoalescer = ScaleAnimationRequestCoalescer()
 
     override fun onAttach() {
         requestInitialStyleFromParent()
@@ -84,7 +84,7 @@ internal class ScaleLayoutModifier(
     override fun onReset() {
         updateJob?.cancel()
         updateJob = null
-        lastAnimationRequest = null
+        animationRequestCoalescer.reset()
         scale = 1f
         zIndex = 0f
         customAnimationSpec = null
@@ -125,14 +125,15 @@ internal class ScaleLayoutModifier(
                 scale = scale,
                 zIndex = zIndex,
                 animationSpec = animationSpec,
+                focused = focused,
                 pressed = pressed,
+                hovered = hovered,
             )
 
         this.scale = scale
         this.zIndex = zIndex
 
-        if (animationRequest == lastAnimationRequest) return
-        lastAnimationRequest = animationRequest
+        if (!animationRequestCoalescer.shouldAnimate(animationRequest)) return
 
         updateJob?.cancel()
         updateJob =
@@ -192,32 +193,57 @@ internal data class ScaleAnimationRequest(
     val animationSpecKey: ScaleAnimationSpecKey,
 )
 
-internal sealed interface ScaleAnimationSpecKey {
-    data class Default(val durationMillis: Int) : ScaleAnimationSpecKey
+internal data class ScaleAnimationSpecKey(
+    val animationSpec: AnimationSpec<Float>,
+)
 
-    data class Custom(val animationSpec: AnimationSpec<Float>) : ScaleAnimationSpecKey
+internal class ScaleAnimationRequestCoalescer {
+    private var lastAnimationRequest: ScaleAnimationRequest? = null
+
+    fun shouldAnimate(animationRequest: ScaleAnimationRequest): Boolean {
+        if (animationRequest == lastAnimationRequest) return false
+
+        lastAnimationRequest = animationRequest
+        return true
+    }
+
+    fun reset() {
+        lastAnimationRequest = null
+    }
 }
 
 internal fun scaleAnimationRequest(
     scale: Float,
     zIndex: Float,
     animationSpec: AnimationSpec<Float>?,
+    focused: Boolean,
     pressed: Boolean,
+    hovered: Boolean,
 ): ScaleAnimationRequest =
     ScaleAnimationRequest(
         scale = scale,
         zIndex = zIndex,
-        animationSpecKey = scaleAnimationSpecKey(animationSpec = animationSpec, pressed = pressed),
+        animationSpecKey =
+            scaleAnimationSpecKey(
+                animationSpec = animationSpec,
+                focused = focused,
+                pressed = pressed,
+                hovered = hovered,
+            ),
     )
 
 internal fun scaleAnimationSpecKey(
     animationSpec: AnimationSpec<Float>?,
+    focused: Boolean,
     pressed: Boolean,
+    hovered: Boolean,
 ): ScaleAnimationSpecKey =
-    animationSpec?.let(ScaleAnimationSpecKey::Custom)
-        ?: ScaleAnimationSpecKey.Default(
-            durationMillis = if (pressed) DEFAULT_PRESSED_SCALE_ANIMATION_DURATION_MILLIS else DEFAULT_SCALE_ANIMATION_DURATION_MILLIS,
-        )
-
-private const val DEFAULT_SCALE_ANIMATION_DURATION_MILLIS = 300
-private const val DEFAULT_PRESSED_SCALE_ANIMATION_DURATION_MILLIS = 120
+    ScaleAnimationSpecKey(
+        animationSpec =
+            animationSpec
+                ?: defaultScaleAnimationSpec(
+                    focused = focused,
+                    pressed = pressed,
+                    hovered = hovered,
+                ),
+    )

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -1,0 +1,117 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.tween
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ScaleAnimationRequestTest {
+    @Test
+    fun matchingDefaultRequestsAreEqual() {
+        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val second = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun changedScaleCreatesDifferentRequest() {
+        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val second = request(scale = 1.2f, zIndex = 0.5f, pressed = false)
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun changedZIndexCreatesDifferentRequest() {
+        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val second = request(scale = 1.1f, zIndex = 0f, pressed = false)
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun defaultPressedAndNonPressedRequestsAreDifferent() {
+        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val second = request(scale = 1.1f, zIndex = 0.5f, pressed = true)
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun defaultFocusedAndHoveredRequestsWithSameTargetAreEqual() {
+        val focused =
+            request(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                pressed = false,
+            )
+        val hovered =
+            request(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                pressed = false,
+            )
+
+        assertEquals(focused, hovered)
+    }
+
+    @Test
+    fun matchingCustomSpecRequestsAreEqual() {
+        val spec = tween<Float>(durationMillis = 100)
+        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false, animationSpec = spec)
+        val second = request(scale = 1.1f, zIndex = 0.5f, pressed = false, animationSpec = spec)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun differentCustomSpecRequestsAreDifferent() {
+        val first =
+            request(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                pressed = false,
+                animationSpec = tween(durationMillis = 100),
+            )
+        val second =
+            request(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                pressed = false,
+                animationSpec = tween(durationMillis = 200),
+            )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun customAndDefaultRequestsAreDifferent() {
+        val custom =
+            request(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                pressed = false,
+                animationSpec = tween(durationMillis = 300),
+            )
+        val default = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+
+        assertNotEquals(custom, default)
+    }
+
+    private fun request(
+        scale: Float,
+        zIndex: Float,
+        pressed: Boolean,
+        animationSpec: AnimationSpec<Float>? = null,
+    ): ScaleAnimationRequest =
+        scaleAnimationRequest(
+            scale = scale,
+            zIndex = zIndex,
+            animationSpec = animationSpec,
+            pressed = pressed,
+        )
+}

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -6,36 +6,38 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.tween
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class ScaleAnimationRequestTest {
     @Test
     fun matchingDefaultRequestsAreEqual() {
-        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
-        val second = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val first = request(scale = 1.1f, zIndex = 0.5f)
+        val second = request(scale = 1.1f, zIndex = 0.5f)
 
         assertEquals(first, second)
     }
 
     @Test
     fun changedScaleCreatesDifferentRequest() {
-        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
-        val second = request(scale = 1.2f, zIndex = 0.5f, pressed = false)
+        val first = request(scale = 1.1f, zIndex = 0.5f)
+        val second = request(scale = 1.2f, zIndex = 0.5f)
 
         assertNotEquals(first, second)
     }
 
     @Test
     fun changedZIndexCreatesDifferentRequest() {
-        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
-        val second = request(scale = 1.1f, zIndex = 0f, pressed = false)
+        val first = request(scale = 1.1f, zIndex = 0.5f)
+        val second = request(scale = 1.1f, zIndex = 0f)
 
         assertNotEquals(first, second)
     }
 
     @Test
     fun defaultPressedAndNonPressedRequestsAreDifferent() {
-        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val first = request(scale = 1.1f, zIndex = 0.5f)
         val second = request(scale = 1.1f, zIndex = 0.5f, pressed = true)
 
         assertNotEquals(first, second)
@@ -47,13 +49,13 @@ class ScaleAnimationRequestTest {
             request(
                 scale = 1.1f,
                 zIndex = 0.5f,
-                pressed = false,
+                focused = true,
             )
         val hovered =
             request(
                 scale = 1.1f,
                 zIndex = 0.5f,
-                pressed = false,
+                hovered = true,
             )
 
         assertEquals(focused, hovered)
@@ -62,8 +64,8 @@ class ScaleAnimationRequestTest {
     @Test
     fun matchingCustomSpecRequestsAreEqual() {
         val spec = tween<Float>(durationMillis = 100)
-        val first = request(scale = 1.1f, zIndex = 0.5f, pressed = false, animationSpec = spec)
-        val second = request(scale = 1.1f, zIndex = 0.5f, pressed = false, animationSpec = spec)
+        val first = request(scale = 1.1f, zIndex = 0.5f, animationSpec = spec)
+        val second = request(scale = 1.1f, zIndex = 0.5f, animationSpec = spec)
 
         assertEquals(first, second)
     }
@@ -74,14 +76,12 @@ class ScaleAnimationRequestTest {
             request(
                 scale = 1.1f,
                 zIndex = 0.5f,
-                pressed = false,
                 animationSpec = tween(durationMillis = 100),
             )
         val second =
             request(
                 scale = 1.1f,
                 zIndex = 0.5f,
-                pressed = false,
                 animationSpec = tween(durationMillis = 200),
             )
 
@@ -94,24 +94,64 @@ class ScaleAnimationRequestTest {
             request(
                 scale = 1.1f,
                 zIndex = 0.5f,
-                pressed = false,
                 animationSpec = tween(durationMillis = 300),
             )
-        val default = request(scale = 1.1f, zIndex = 0.5f, pressed = false)
+        val default = request(scale = 1.1f, zIndex = 0.5f)
 
         assertNotEquals(custom, default)
+    }
+
+    @Test
+    fun coalescerAnimatesFirstRequest() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        assertTrue(coalescer.shouldAnimate(request(scale = 1.1f, zIndex = 0.5f)))
+    }
+
+    @Test
+    fun coalescerSkipsMatchingRequest() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+        val request = request(scale = 1.1f, zIndex = 0.5f)
+
+        coalescer.shouldAnimate(request)
+
+        assertFalse(coalescer.shouldAnimate(request))
+    }
+
+    @Test
+    fun coalescerAnimatesChangedRequest() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(request(scale = 1.1f, zIndex = 0.5f))
+
+        assertTrue(coalescer.shouldAnimate(request(scale = 1.2f, zIndex = 0.5f)))
+    }
+
+    @Test
+    fun coalescerAnimatesMatchingRequestAfterReset() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+        val request = request(scale = 1.1f, zIndex = 0.5f)
+
+        coalescer.shouldAnimate(request)
+        coalescer.reset()
+
+        assertTrue(coalescer.shouldAnimate(request))
     }
 
     private fun request(
         scale: Float,
         zIndex: Float,
-        pressed: Boolean,
+        focused: Boolean = false,
+        pressed: Boolean = false,
+        hovered: Boolean = false,
         animationSpec: AnimationSpec<Float>? = null,
     ): ScaleAnimationRequest =
         scaleAnimationRequest(
             scale = scale,
             zIndex = zIndex,
             animationSpec = animationSpec,
+            focused = focused,
             pressed = pressed,
+            hovered = hovered,
         )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Coalesce `ScaleLayoutModifier` animation updates by comparing the last effective request before canceling/relaunching `updateJob`.
- Use `defaultScaleAnimationSpec(...)` itself as the default spec-key source of truth, preserving focused/pressed/hovered inputs and custom `AnimationSpec` equality.
- Reset coalescing state from `onReset()` and add common tests for request/spec key equality plus coalescer first/update/reset behavior.

## Testing
- `./gradlew :style:spotlessApply`
- `./gradlew :style:spotlessCheck :style:jvmTest`
- `./gradlew :style:spotlessApply :style:spotlessCheck :style:jvmTest`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5e65aa7-53fd-4e8a-85ed-60da0abbbfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5e65aa7-53fd-4e8a-85ed-60da0abbbfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

