### PR TITLE
fix(build): AGP 9 KMP compatibility on top of renovate/major-agp

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,14 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 ## Android ##
 # Suppress Cache Fix warning
 org.gradle.android.cache-fix.ignoreVersionCheck=true
+# Opt out of AGP 9's built-in Kotlin so the Kotlin Multiplatform plugin can
+# register its own `kotlin` extension on Android library modules.
+android.builtInKotlin=false
+# Opt out of AGP 9's new DSL until the Kotlin Multiplatform plugin's
+# `androidTarget()` is compatible with it. The KMP plugin currently casts to
+# the legacy `BaseExtension`, which `android.newDsl=true` no longer exposes.
+# See https://kotl.in/gradle/agp-new-kmp for the longer-term migration.
+android.newDsl=false
 
 ## RELEASE DETAILS ##
 GROUP=io.daio.wild

--- a/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/AndroidApplicationConventionPlugin.kt
@@ -1,6 +1,6 @@
 package io.daio.gradle
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -16,7 +16,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             configureAndroid()
 
-            extensions.configure<BaseExtension> {
+            extensions.configure<ApplicationExtension> {
                 compileOptions {
                     // https://developer.android.com/studio/write/java8-support
                     isCoreLibraryDesugaringEnabled = true

--- a/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/AndroidLibraryConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/AndroidLibraryConventionPlugin.kt
@@ -1,11 +1,7 @@
 package io.daio.gradle
 
-import com.android.build.gradle.internal.crash.afterEvaluate
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.extra
-import org.gradle.kotlin.dsl.repositories
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {

--- a/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/Java.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/Java.kt
@@ -10,7 +10,7 @@ import org.gradle.kotlin.dsl.withType
 fun Project.configureJava() {
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(Versions.JAVA_VERSION))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 

--- a/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/Versions.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/io/daio/gradle/Versions.kt
@@ -9,7 +9,6 @@ object Versions {
     const val COMPILE_SDK = 36
     const val MIN_SDK = 23
     const val TARGET_SDK = 36
-    const val JAVA_VERSION = 21
 }
 
 val Project.libs: VersionCatalog

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-agp = "8.13.2"
+agp = "9.0.1"
 activity-compose = "1.12.2"
 androidx-appcompat = "1.7.1"
 benchmark = "1.4.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/playbook/shared/build.gradle.kts
+++ b/playbook/shared/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 android {
     namespace = "io.daio.wild.playbook.shared"
-    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 }
 
 kotlin {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This branch targets `renovate/major-agp` so it can be merged into [PR #228](https://github.com/Daio-io/wild/pull/228) before that PR lands on `main`.

### Changes
- **Gradle wrapper**: `9.3.0` → `9.4.1` (matches the AGP 9 / Kotlin Gradle plugin expectations from the review notes).
- **`gradle.properties`**: set `android.builtInKotlin=false` and `android.newDsl=false` so the JetBrains Kotlin Multiplatform plugin can keep registering its `kotlin` extension and continue using the legacy `BaseExtension` path until the project migrates to `com.android.kotlin.multiplatform.library` (see [kotl.in/gradle/agp-new-kmp](https://kotl.in/gradle/agp-new-kmp)).
- **`AndroidApplicationConventionPlugin`**: configure core library desugaring on `ApplicationExtension` instead of `BaseExtension`.
- **`AndroidLibraryConventionPlugin`**: remove stray internal Gradle imports that do not belong in convention code.
- **`Versions` / `Java`**: drop the unused `JAVA_VERSION` constant and keep the Java toolchain on 21 via `JavaLanguageVersion.of(21)`.
- **`playbook/shared`**: remove the redundant `sourceSets["main"].manifest` override (KMP already uses `src/androidMain/AndroidManifest.xml` by default).

### Note on `Android.kt` / Roborazzi
A trial migration of `configureAndroid()` to `com.android.build.api.dsl.CommonExtension` does not compile in `build-logic` because the nested Kotlin DSL (`defaultConfig { }`, `compileOptions { }`) for that type is not on the convention plugin compile classpath. With `android.newDsl=false`, `BaseExtension` remains the correct choice for shared Android configuration until a fuller KMP + AGP migration.

### Verification
- `./gradlew :build-logic:convention:compileKotlin spotlessApply`
- `./gradlew :playbook:shared:assemble :playbook:android:assembleDebug`

Full `./gradlew assemble` still fails on `:playbook:web:compileKotlinJs` due to an existing deprecation-as-error in `Main.kt` (unrelated to this change set).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-524d343e-5172-4a76-af95-d43a8625b5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-524d343e-5172-4a76-af95-d43a8625b5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

