### PR TITLE
docs: enable confetti on docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <div align="center">
 <img src="wild-logo-circle.svg" alt="Wild" />
 <br/>
-<script src="https://api.nice.sbs/embed.js" data-button="n_MnNezGB3MUjd" data-theme="dark" data-size="md" async></script>
+<script src="https://api.nice.sbs/embed.js" data-button="n_MnNezGB3MUjd" data-theme="dark" data-size="md" data-confetti="true" async></script>
 </div>
 
 Building blocks for your Compose Multiplatform Design System.


### PR DESCRIPTION
## Summary
- enable confetti on the Nice embed in the docs homepage
- set `data-confetti="true"` on the existing script tag

## Testing
- not run (content-only docs change)