### PR TITLE
fix: correct overlapping interaction source state

### DIFF
--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
@@ -90,7 +90,7 @@ internal class InteractionSourceElement(
     }
 
     override fun hashCode(): Int {
-        var result = System.identityHashCode(interactionSource)
+        var result = interactionSource?.hashCode() ?: 0
         result = 31 * result + childTraversalKey.hashCode()
         return result
     }

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
@@ -65,8 +65,10 @@ internal class InteractionSourceElement(
         )
 
     override fun update(node: InteractionSourceNode) {
-        node.updateInteractionSource(interactionSource)
-        node.childTraversalKey = childTraversalKey
+        node.update(
+            interactionSource = interactionSource,
+            childTraversalKey = childTraversalKey,
+        )
     }
 
     override fun InspectorInfo.inspectableProperties() {
@@ -81,14 +83,14 @@ internal class InteractionSourceElement(
 
         other as InteractionSourceElement
 
-        if (interactionSource != other.interactionSource) return false
+        if (interactionSource !== other.interactionSource) return false
         if (childTraversalKey != other.childTraversalKey) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = interactionSource.hashCode()
+        var result = System.identityHashCode(interactionSource)
         result = 31 * result + childTraversalKey.hashCode()
         return result
     }
@@ -98,25 +100,33 @@ internal class InteractionSourceNode(
     var interactionSource: InteractionSource?,
     var childTraversalKey: Any,
 ) : Modifier.Node(), TraversableNode {
-    var focused: Boolean = false
-        private set
-
-    var hovered: Boolean = false
-        private set
-
-    var pressed: Boolean = false
-        private set
-
     private var collectionJob: Job? = null
+    private val activePresses = mutableSetOf<PressInteraction.Press>()
+    private val activeHovers = mutableSetOf<HoverInteraction.Enter>()
+    private val activeFocuses = mutableSetOf<FocusInteraction.Focus>()
+    private var lastDispatchedStateBits: Int = STATE_NONE
 
     /**
-     * Updates the [InteractionSource] and restarts the collection coroutine.
-     * If the source hasn't changed, this is a no-op.
+     * Updates the [InteractionSource] and child traversal key atomically.
+     * If only the key changes, the current state is dispatched once to the new subtree.
      */
-    fun updateInteractionSource(newSource: InteractionSource?) {
-        if (interactionSource === newSource) return
-        interactionSource = newSource
-        restartCollection()
+    fun update(
+        interactionSource: InteractionSource?,
+        childTraversalKey: Any,
+    ) {
+        val sourceChanged = this.interactionSource !== interactionSource
+        val keyChanged = this.childTraversalKey != childTraversalKey
+
+        if (!sourceChanged && !keyChanged) return
+
+        this.childTraversalKey = childTraversalKey
+
+        if (sourceChanged) {
+            this.interactionSource = interactionSource
+            restartCollection()
+        } else if (keyChanged) {
+            dispatchCurrentState()
+        }
     }
 
     override fun onAttach() {
@@ -125,7 +135,8 @@ internal class InteractionSourceNode(
 
     private fun restartCollection() {
         collectionJob?.cancel()
-        resetStateAndNotify()
+        collectionJob = null
+        resetState(notify = isAttached)
 
         val source = interactionSource ?: return
 
@@ -133,22 +144,16 @@ internal class InteractionSourceNode(
             coroutineScope.launch {
                 source.interactions.collect { interaction ->
                     when (interaction) {
-                        is PressInteraction.Press -> pressed = true
-                        is PressInteraction.Release -> pressed = false
-                        is PressInteraction.Cancel -> pressed = false
-                        is HoverInteraction.Enter -> hovered = true
-                        is HoverInteraction.Exit -> hovered = false
-                        is FocusInteraction.Focus -> focused = true
-                        is FocusInteraction.Unfocus -> focused = false
+                        is PressInteraction.Press -> activePresses += interaction
+                        is PressInteraction.Release -> activePresses -= interaction.press
+                        is PressInteraction.Cancel -> activePresses -= interaction.press
+                        is HoverInteraction.Enter -> activeHovers += interaction
+                        is HoverInteraction.Exit -> activeHovers -= interaction.enter
+                        is FocusInteraction.Focus -> activeFocuses += interaction
+                        is FocusInteraction.Unfocus -> activeFocuses -= interaction.focus
                     }
 
-                    notifyInteractionsChanged(
-                        Interactions(
-                            focused = focused,
-                            hovered = hovered,
-                            pressed = pressed,
-                        ),
-                    )
+                    dispatchIfChanged()
                 }
             }
     }
@@ -156,40 +161,45 @@ internal class InteractionSourceNode(
     override fun onDetach() {
         collectionJob?.cancel()
         collectionJob = null
-        resetState()
+        resetState(notify = false)
     }
 
     override fun onReset() {
         collectionJob?.cancel()
         collectionJob = null
-        resetStateAndNotify()
+        resetState(notify = isAttached)
     }
 
-    /**
-     * Resets interaction state without notifying children.
-     * Used during detach when children may already be partially detached.
-     */
-    private fun resetState() {
-        hovered = false
-        focused = false
-        pressed = false
+    private fun resetState(notify: Boolean) {
+        activePresses.clear()
+        activeHovers.clear()
+        activeFocuses.clear()
+
+        if (notify && lastDispatchedStateBits != STATE_NONE) {
+            lastDispatchedStateBits = STATE_NONE
+            notifyInteractionsChanged(interactionsFor(STATE_NONE))
+        } else {
+            lastDispatchedStateBits = STATE_NONE
+        }
     }
 
-    /**
-     * Resets interaction state and notifies children.
-     * Used during reset (node reuse) when children are still attached.
-     */
-    private fun resetStateAndNotify() {
-        hovered = false
-        focused = false
-        pressed = false
-        notifyInteractionsChanged(
-            Interactions(
-                focused = focused,
-                hovered = hovered,
-                pressed = pressed,
-            ),
-        )
+    private fun dispatchCurrentState() {
+        notifyInteractionsChanged(interactionsFor(currentStateBits()))
+    }
+
+    private fun dispatchIfChanged() {
+        val newStateBits = currentStateBits()
+        if (newStateBits == lastDispatchedStateBits) return
+        lastDispatchedStateBits = newStateBits
+        notifyInteractionsChanged(interactionsFor(newStateBits))
+    }
+
+    private fun currentStateBits(): Int {
+        var bits = STATE_NONE
+        if (activePresses.isNotEmpty()) bits = bits or STATE_PRESSED
+        if (activeHovers.isNotEmpty()) bits = bits or STATE_HOVERED
+        if (activeFocuses.isNotEmpty()) bits = bits or STATE_FOCUSED
+        return bits
     }
 
     private fun notifyInteractionsChanged(interactions: Interactions) {
@@ -198,7 +208,25 @@ internal class InteractionSourceNode(
         }
     }
 
-    private companion object InteractionSourceParentKey
+    private companion object {
+        object InteractionSourceParentKey
+
+        const val STATE_NONE = 0
+        const val STATE_PRESSED = 1 shl 0
+        const val STATE_HOVERED = 1 shl 1
+        const val STATE_FOCUSED = 1 shl 2
+
+        val interactionStates =
+            Array(8) { bits ->
+                Interactions(
+                    focused = bits and STATE_FOCUSED != 0,
+                    hovered = bits and STATE_HOVERED != 0,
+                    pressed = bits and STATE_PRESSED != 0,
+                )
+            }
+
+        fun interactionsFor(bits: Int): Interactions = interactionStates[bits]
+    }
 
     override val traverseKey: Any
         get() = InteractionSourceParentKey

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/StyleTraversalIntegrationTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/StyleTraversalIntegrationTest.kt
@@ -352,8 +352,13 @@ class StyleTraversalIntegrationTest {
             runBlocking { source.emit(FocusInteraction.Focus()) }
             waitForIdle()
 
-            assertEquals(1, newObserver.states.size)
-            assertTrue(newObserver.states.single().focused)
+            assertEquals(
+                listOf(
+                    Interactions(focused = false, hovered = false, pressed = false),
+                    Interactions(focused = true, hovered = false, pressed = false),
+                ),
+                newObserver.states,
+            )
             assertEquals(0, oldObserver.states.size)
         }
 

--- a/style/src/commonTest/kotlin/io/daio/wild/style/modifiers/InteractionSourceElementTest.kt
+++ b/style/src/commonTest/kotlin/io/daio/wild/style/modifiers/InteractionSourceElementTest.kt
@@ -1,0 +1,297 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.TraversableNode
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import io.daio.wild.foundation.ExperimentalWildApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalWildApi::class, ExperimentalTestApi::class)
+class InteractionSourceElementTest {
+    @Test
+    fun overlappingPressesStayPressedUntilFinalRelease() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val recorder = InteractionRecorder()
+
+            setContent {
+                ParentWithObservers(
+                    interactionSource = source,
+                    childTraversalKey = KeyA,
+                    observerA = recorder,
+                )
+            }
+
+            val press1 = PressInteraction.Press(androidx.compose.ui.geometry.Offset.Zero)
+            val press2 = PressInteraction.Press(androidx.compose.ui.geometry.Offset.Zero)
+
+            runOnIdle {
+                assertTrue(source.tryEmit(press1))
+                assertTrue(source.tryEmit(press2))
+                assertTrue(source.tryEmit(PressInteraction.Release(press1)))
+            }
+
+            runOnIdle {
+                assertEquals(listOf(Interactions(focused = false, hovered = false, pressed = true)), recorder.events)
+                assertTrue(source.tryEmit(PressInteraction.Release(press2)))
+            }
+
+            runOnIdle {
+                assertEquals(
+                    listOf(
+                        Interactions(focused = false, hovered = false, pressed = true),
+                        Interactions(focused = false, hovered = false, pressed = false),
+                    ),
+                    recorder.events,
+                )
+            }
+        }
+
+    @Test
+    fun overlappingHoverAndFocusStayActiveUntilTheirFinalTerminalInteractions() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val recorder = InteractionRecorder()
+
+            setContent {
+                ParentWithObservers(
+                    interactionSource = source,
+                    childTraversalKey = KeyA,
+                    observerA = recorder,
+                )
+            }
+
+            val enter1 = HoverInteraction.Enter()
+            val enter2 = HoverInteraction.Enter()
+            val focus1 = FocusInteraction.Focus()
+            val focus2 = FocusInteraction.Focus()
+
+            runOnIdle {
+                assertTrue(source.tryEmit(enter1))
+                assertTrue(source.tryEmit(enter2))
+                assertTrue(source.tryEmit(HoverInteraction.Exit(enter1)))
+                assertTrue(source.tryEmit(focus1))
+                assertTrue(source.tryEmit(focus2))
+                assertTrue(source.tryEmit(FocusInteraction.Unfocus(focus1)))
+            }
+
+            runOnIdle {
+                assertEquals(
+                    listOf(
+                        Interactions(focused = false, hovered = true, pressed = false),
+                        Interactions(focused = true, hovered = true, pressed = false),
+                    ),
+                    recorder.events,
+                )
+
+                assertTrue(source.tryEmit(HoverInteraction.Exit(enter2)))
+                assertTrue(source.tryEmit(FocusInteraction.Unfocus(focus2)))
+            }
+
+            runOnIdle {
+                assertEquals(
+                    listOf(
+                        Interactions(focused = false, hovered = true, pressed = false),
+                        Interactions(focused = true, hovered = true, pressed = false),
+                        Interactions(focused = true, hovered = false, pressed = false),
+                        Interactions(focused = false, hovered = false, pressed = false),
+                    ),
+                    recorder.events,
+                )
+            }
+        }
+
+    @Test
+    fun unknownTerminalInteractionsDoNotNotify() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val recorder = InteractionRecorder()
+
+            setContent {
+                ParentWithObservers(
+                    interactionSource = source,
+                    childTraversalKey = KeyA,
+                    observerA = recorder,
+                )
+            }
+
+            runOnIdle {
+                assertTrue(source.tryEmit(PressInteraction.Release(PressInteraction.Press(androidx.compose.ui.geometry.Offset.Zero))))
+                assertTrue(source.tryEmit(HoverInteraction.Exit(HoverInteraction.Enter())))
+                assertTrue(source.tryEmit(FocusInteraction.Unfocus(FocusInteraction.Focus())))
+            }
+
+            runOnIdle {
+                assertEquals(emptyList(), recorder.events)
+            }
+        }
+
+    @Test
+    fun sourceReplacementStopsOldSourceEventsAndDispatchesReset() =
+        runComposeUiTest {
+            val sourceA = MutableInteractionSource()
+            val sourceB = MutableInteractionSource()
+            val recorder = InteractionRecorder()
+            var interactionSource by mutableStateOf<androidx.compose.foundation.interaction.InteractionSource?>(sourceA)
+
+            setContent {
+                ParentWithObservers(
+                    interactionSource = interactionSource,
+                    childTraversalKey = KeyA,
+                    observerA = recorder,
+                )
+            }
+
+            val pressA = PressInteraction.Press(androidx.compose.ui.geometry.Offset.Zero)
+
+            runOnIdle {
+                assertTrue(sourceA.tryEmit(pressA))
+            }
+
+            runOnIdle {
+                interactionSource = sourceB
+            }
+
+            runOnIdle {
+                assertTrue(sourceA.tryEmit(PressInteraction.Release(pressA)))
+                assertTrue(sourceB.tryEmit(PressInteraction.Press(androidx.compose.ui.geometry.Offset.Zero)))
+            }
+
+            runOnIdle {
+                assertEquals(
+                    listOf(
+                        Interactions(focused = false, hovered = false, pressed = true),
+                        Interactions(focused = false, hovered = false, pressed = false),
+                        Interactions(focused = false, hovered = false, pressed = true),
+                    ),
+                    recorder.events,
+                )
+            }
+        }
+
+    @Test
+    fun keyOnlyUpdateDispatchesCurrentStateToNewMatchingDescendants() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val recorderA = InteractionRecorder()
+            val recorderB = InteractionRecorder()
+            var childTraversalKey by mutableStateOf(KeyA as Any)
+
+            setContent {
+                ParentWithObservers(
+                    interactionSource = source,
+                    childTraversalKey = childTraversalKey,
+                    observerA = recorderA,
+                    observerB = recorderB,
+                )
+            }
+
+            val press = PressInteraction.Press(androidx.compose.ui.geometry.Offset.Zero)
+
+            runOnIdle {
+                assertTrue(source.tryEmit(press))
+            }
+
+            runOnIdle {
+                childTraversalKey = KeyB
+            }
+
+            runOnIdle {
+                assertTrue(source.tryEmit(PressInteraction.Release(press)))
+            }
+
+            runOnIdle {
+                assertEquals(
+                    listOf(Interactions(focused = false, hovered = false, pressed = true)),
+                    recorderA.events,
+                )
+                assertEquals(
+                    listOf(
+                        Interactions(focused = false, hovered = false, pressed = true),
+                        Interactions(focused = false, hovered = false, pressed = false),
+                    ),
+                    recorderB.events,
+                )
+            }
+        }
+}
+
+@OptIn(ExperimentalWildApi::class)
+@androidx.compose.runtime.Composable
+private fun ParentWithObservers(
+    interactionSource: androidx.compose.foundation.interaction.InteractionSource?,
+    childTraversalKey: Any,
+    observerA: InteractionRecorder,
+    observerB: InteractionRecorder? = null,
+) {
+    Box(
+        modifier =
+            Modifier.interactionSourceNode(
+                interactionSource = interactionSource,
+                childTraversalKey = childTraversalKey,
+            ),
+    ) {
+        Box(modifier = Modifier.interactionObserverNode(KeyA, observerA))
+        observerB?.let {
+            Box(modifier = Modifier.interactionObserverNode(KeyB, it))
+        }
+    }
+}
+
+private class InteractionRecorder {
+    val events = mutableListOf<Interactions>()
+}
+
+private fun Modifier.interactionObserverNode(
+    key: Any,
+    recorder: InteractionRecorder,
+): Modifier = this then InteractionObserverElement(key, recorder)
+
+private data class InteractionObserverElement(
+    private val key: Any,
+    private val recorder: InteractionRecorder,
+) : ModifierNodeElement<InteractionObserverNode>() {
+    override fun create(): InteractionObserverNode = InteractionObserverNode(key, recorder)
+
+    override fun update(node: InteractionObserverNode) {
+        node.key = key
+        node.recorder = recorder
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "InteractionObserverElement"
+    }
+}
+
+private class InteractionObserverNode(
+    var key: Any,
+    var recorder: InteractionRecorder,
+) : Modifier.Node(),
+    InteractionSourceObserverNode,
+    TraversableNode {
+    override fun onInteractionStateChanged(interactions: Interactions) {
+        recorder.events += interactions
+    }
+
+    override val traverseKey: Any
+        get() = key
+}
+
+private data object KeyA
+
+private data object KeyB

--- a/style/src/commonTest/kotlin/io/daio/wild/style/modifiers/InteractionSourceElementTest.kt
+++ b/style/src/commonTest/kotlin/io/daio/wild/style/modifiers/InteractionSourceElementTest.kt
@@ -27,10 +27,10 @@ class InteractionSourceElementTest {
     fun overlappingPressesStayPressedUntilFinalRelease() =
         runComposeUiTest {
             val source = MutableInteractionSource()
-            val recorder = InteractionRecorder()
+            val recorder = TestInteractionRecorder()
 
             setContent {
-                ParentWithObservers(
+                TestParentWithObservers(
                     interactionSource = source,
                     childTraversalKey = KeyA,
                     observerA = recorder,
@@ -66,10 +66,10 @@ class InteractionSourceElementTest {
     fun overlappingHoverAndFocusStayActiveUntilTheirFinalTerminalInteractions() =
         runComposeUiTest {
             val source = MutableInteractionSource()
-            val recorder = InteractionRecorder()
+            val recorder = TestInteractionRecorder()
 
             setContent {
-                ParentWithObservers(
+                TestParentWithObservers(
                     interactionSource = source,
                     childTraversalKey = KeyA,
                     observerA = recorder,
@@ -120,10 +120,10 @@ class InteractionSourceElementTest {
     fun unknownTerminalInteractionsDoNotNotify() =
         runComposeUiTest {
             val source = MutableInteractionSource()
-            val recorder = InteractionRecorder()
+            val recorder = TestInteractionRecorder()
 
             setContent {
-                ParentWithObservers(
+                TestParentWithObservers(
                     interactionSource = source,
                     childTraversalKey = KeyA,
                     observerA = recorder,
@@ -137,7 +137,7 @@ class InteractionSourceElementTest {
             }
 
             runOnIdle {
-                assertEquals(emptyList(), recorder.events)
+                assertEquals(emptyList<Interactions>(), recorder.events)
             }
         }
 
@@ -146,11 +146,11 @@ class InteractionSourceElementTest {
         runComposeUiTest {
             val sourceA = MutableInteractionSource()
             val sourceB = MutableInteractionSource()
-            val recorder = InteractionRecorder()
+            val recorder = TestInteractionRecorder()
             var interactionSource by mutableStateOf<androidx.compose.foundation.interaction.InteractionSource?>(sourceA)
 
             setContent {
-                ParentWithObservers(
+                TestParentWithObservers(
                     interactionSource = interactionSource,
                     childTraversalKey = KeyA,
                     observerA = recorder,
@@ -188,12 +188,12 @@ class InteractionSourceElementTest {
     fun keyOnlyUpdateDispatchesCurrentStateToNewMatchingDescendants() =
         runComposeUiTest {
             val source = MutableInteractionSource()
-            val recorderA = InteractionRecorder()
-            val recorderB = InteractionRecorder()
+            val recorderA = TestInteractionRecorder()
+            val recorderB = TestInteractionRecorder()
             var childTraversalKey by mutableStateOf(KeyA as Any)
 
             setContent {
-                ParentWithObservers(
+                TestParentWithObservers(
                     interactionSource = source,
                     childTraversalKey = childTraversalKey,
                     observerA = recorderA,
@@ -233,11 +233,11 @@ class InteractionSourceElementTest {
 
 @OptIn(ExperimentalWildApi::class)
 @androidx.compose.runtime.Composable
-private fun ParentWithObservers(
+private fun TestParentWithObservers(
     interactionSource: androidx.compose.foundation.interaction.InteractionSource?,
     childTraversalKey: Any,
-    observerA: InteractionRecorder,
-    observerB: InteractionRecorder? = null,
+    observerA: TestInteractionRecorder,
+    observerB: TestInteractionRecorder? = null,
 ) {
     Box(
         modifier =
@@ -253,18 +253,18 @@ private fun ParentWithObservers(
     }
 }
 
-private class InteractionRecorder {
+private class TestInteractionRecorder {
     val events = mutableListOf<Interactions>()
 }
 
 private fun Modifier.interactionObserverNode(
     key: Any,
-    recorder: InteractionRecorder,
-): Modifier = this then InteractionObserverElement(key, recorder)
+    recorder: TestInteractionRecorder,
+): Modifier = this then TestInteractionObserverElement(key, recorder)
 
-private data class InteractionObserverElement(
+private data class TestInteractionObserverElement(
     private val key: Any,
-    private val recorder: InteractionRecorder,
+    private val recorder: TestInteractionRecorder,
 ) : ModifierNodeElement<InteractionObserverNode>() {
     override fun create(): InteractionObserverNode = InteractionObserverNode(key, recorder)
 
@@ -280,7 +280,7 @@ private data class InteractionObserverElement(
 
 private class InteractionObserverNode(
     var key: Any,
-    var recorder: InteractionRecorder,
+    var recorder: TestInteractionRecorder,
 ) : Modifier.Node(),
     InteractionSourceObserverNode,
     TraversableNode {


### PR DESCRIPTION
## Summary
- track active press, hover, and focus interactions instead of toggling booleans per event
- dispatch interaction updates only when the effective state changes and update source/key atomically
- add Compose UI integration tests for overlapping interactions, source replacement, and key-only traversal updates

## Verification
- `./gradlew :style:jvmTest`
- `./gradlew :style:spotlessCheck`

Linear: THE-223