### PR TITLE
perf: skip no-op style graphics layers

### DIFF
--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -166,9 +166,15 @@ internal class ScaleLayoutModifier(
     ): MeasureResult {
         val placeable = measurable.measure(constraints)
         return layout(placeable.width, placeable.height) {
-            placeable.placeWithLayer(0, 0, zIndex = zIndexState.value) {
-                scaleX = scaleState.value
-                scaleY = scaleState.value
+            val animatedScale = scaleState.value
+            val animatedZIndex = zIndexState.value
+            if (needsScaleLayer(animatedScale, animatedZIndex)) {
+                placeable.placeWithLayer(0, 0, zIndex = animatedZIndex) {
+                    scaleX = animatedScale
+                    scaleY = animatedScale
+                }
+            } else {
+                placeable.place(0, 0)
             }
         }
     }
@@ -186,6 +192,11 @@ internal class ScaleLayoutModifier(
         )
     }
 }
+
+internal fun needsScaleLayer(
+    animatedScale: Float,
+    zIndex: Float,
+): Boolean = animatedScale != 1f || zIndex != 0f
 
 internal data class ScaleAnimationRequest(
     val scale: Float,

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ShapeLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ShapeLayoutElement.kt
@@ -18,6 +18,10 @@ import io.daio.wild.style.StyleScope
 
 /**
  * Applies the main [Shape] to the element as part of the [StyleScopeParentNode].
+ *
+ * This layer remains separate from [ScaleLayoutModifier] because [BorderNode] is ordered between
+ * them. The border must scale with the surface while remaining outside this inner shape clip, such
+ * as when a focus ring uses a positive inset.
  */
 internal class ShapeLayoutElement(
     val shape: Shape = RectangleShape,
@@ -98,14 +102,15 @@ internal class ShapeLayoutModifier(
         return layout(placeable.width, placeable.height) {
             val currentShape = this@ShapeLayoutModifier.shape
             val currentAlpha = this@ShapeLayoutModifier.alpha
-            if (needsShapeLayer(currentShape, currentAlpha)) {
+            val layerMode = shapeLayerMode(currentShape, currentAlpha)
+            if (layerMode.needsLayer) {
                 placeable.placeWithLayer(0, 0) {
                     alpha = currentAlpha
                     shape = currentShape
                     clip = true
-                    // Auto lets Compose choose the cheapest isolation required for
-                    // clipping and group alpha. Offscreen is only selected when
-                    // overlapping content or another operation requires it.
+                    // Auto avoids an offscreen buffer for opaque clipping. For alpha below 1f,
+                    // Auto preserves group alpha by rendering to an offscreen buffer. We cannot
+                    // use ModulateAlpha because styled content may contain overlapping draws.
                     compositingStrategy = CompositingStrategy.Auto
                 }
             } else {
@@ -126,9 +131,28 @@ internal class ShapeLayoutModifier(
 internal fun needsShapeLayer(
     shape: Shape,
     alpha: Float,
-): Boolean {
+): Boolean = shapeLayerMode(shape, alpha).needsLayer
+
+internal fun shapeLayerMode(
+    shape: Shape,
+    alpha: Float,
+): ShapeLayerMode {
     // RectangleShape is intentionally checked by identity: Shape has no
     // cross-platform value equality contract, and a custom rectangle-equivalent
     // shape may still carry different outline or clip semantics.
-    return shape !== RectangleShape || alpha != 1f
+    val clipsToShape = shape !== RectangleShape
+    val appliesGroupAlpha = alpha != 1f
+    return when {
+        clipsToShape && appliesGroupAlpha -> ShapeLayerMode.ClipAndGroupAlpha
+        clipsToShape -> ShapeLayerMode.Clip
+        appliesGroupAlpha -> ShapeLayerMode.GroupAlpha
+        else -> ShapeLayerMode.None
+    }
+}
+
+internal enum class ShapeLayerMode(val needsLayer: Boolean) {
+    None(needsLayer = false),
+    Clip(needsLayer = true),
+    GroupAlpha(needsLayer = true),
+    ClipAndGroupAlpha(needsLayer = true),
 }

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ShapeLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ShapeLayoutElement.kt
@@ -80,9 +80,13 @@ internal class ShapeLayoutModifier(
         alpha: Float,
     ) {
         if (this.shape != shape || this.alpha != alpha) {
+            val hadLayer = needsShapeLayer(this.shape, this.alpha)
             this.shape = shape
             this.alpha = alpha
-            invalidatePlacement()
+            val needsLayer = needsShapeLayer(shape, alpha)
+            if (hadLayer != needsLayer || needsLayer) {
+                invalidatePlacement()
+            }
         }
     }
 
@@ -92,11 +96,20 @@ internal class ShapeLayoutModifier(
     ): MeasureResult {
         val placeable = measurable.measure(constraints)
         return layout(placeable.width, placeable.height) {
-            placeable.placeWithLayer(0, 0) {
-                alpha = this@ShapeLayoutModifier.alpha
-                shape = this@ShapeLayoutModifier.shape
-                clip = true
-                compositingStrategy = CompositingStrategy.Offscreen
+            val currentShape = this@ShapeLayoutModifier.shape
+            val currentAlpha = this@ShapeLayoutModifier.alpha
+            if (needsShapeLayer(currentShape, currentAlpha)) {
+                placeable.placeWithLayer(0, 0) {
+                    alpha = currentAlpha
+                    shape = currentShape
+                    clip = true
+                    // Auto lets Compose choose the cheapest isolation required for
+                    // clipping and group alpha. Offscreen is only selected when
+                    // overlapping content or another operation requires it.
+                    compositingStrategy = CompositingStrategy.Auto
+                }
+            } else {
+                placeable.place(0, 0)
             }
         }
     }
@@ -108,4 +121,14 @@ internal class ShapeLayoutModifier(
             alpha = styleScope.alpha,
         )
     }
+}
+
+internal fun needsShapeLayer(
+    shape: Shape,
+    alpha: Float,
+): Boolean {
+    // RectangleShape is intentionally checked by identity: Shape has no
+    // cross-platform value equality contract, and a custom rectangle-equivalent
+    // shape may still carry different outline or clip semantics.
+    return shape !== RectangleShape || alpha != 1f
 }

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
@@ -1,0 +1,47 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LayerSelectionTest {
+    @Test
+    fun scaleLayerIsSkippedForDefaultValues() {
+        assertFalse(needsScaleLayer(animatedScale = 1f, zIndex = 0f))
+    }
+
+    @Test
+    fun scaleLayerIsUsedForScaleOrZIndex() {
+        assertTrue(needsScaleLayer(animatedScale = 1.01f, zIndex = 0f))
+        assertTrue(needsScaleLayer(animatedScale = 1f, zIndex = 0.5f))
+    }
+
+    @Test
+    fun shapeLayerIsSkippedForOpaqueRectangle() {
+        assertFalse(needsShapeLayer(shape = RectangleShape, alpha = 1f))
+    }
+
+    @Test
+    fun shapeLayerIsUsedForNonRectangleOrTransparency() {
+        assertTrue(needsShapeLayer(shape = testShape, alpha = 1f))
+        assertTrue(needsShapeLayer(shape = RectangleShape, alpha = 0.5f))
+    }
+
+    private val testShape =
+        object : Shape {
+            override fun createOutline(
+                size: Size,
+                layoutDirection: LayoutDirection,
+                density: Density,
+            ): Outline = Outline.Rectangle(Rect(0f, 0f, size.width, size.height))
+        }
+}

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -26,12 +27,24 @@ class LayerSelectionTest {
     }
 
     @Test
-    fun shapeLayerIsSkippedForOpaqueRectangle() {
+    fun shapeLayerModeCoversClipAndGroupAlphaMatrix() {
+        assertEquals(
+            ShapeLayerMode.None,
+            shapeLayerMode(shape = RectangleShape, alpha = 1f),
+        )
+        assertEquals(
+            ShapeLayerMode.Clip,
+            shapeLayerMode(shape = testShape, alpha = 1f),
+        )
+        assertEquals(
+            ShapeLayerMode.GroupAlpha,
+            shapeLayerMode(shape = RectangleShape, alpha = 0.5f),
+        )
+        assertEquals(
+            ShapeLayerMode.ClipAndGroupAlpha,
+            shapeLayerMode(shape = testShape, alpha = 0.5f),
+        )
         assertFalse(needsShapeLayer(shape = RectangleShape, alpha = 1f))
-    }
-
-    @Test
-    fun shapeLayerIsUsedForNonRectangleOrTransparency() {
         assertTrue(needsShapeLayer(shape = testShape, alpha = 1f))
         assertTrue(needsShapeLayer(shape = RectangleShape, alpha = 0.5f))
     }

--- a/style/src/jvmTest/kotlin/io/daio/wild/style/modifiers/StyleLayerRenderingTest.kt
+++ b/style/src/jvmTest/kotlin/io/daio/wild/style/modifiers/StyleLayerRenderingTest.kt
@@ -1,0 +1,394 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.style.modifiers
+
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.daio.wild.foundation.ExperimentalWildApi
+import io.daio.wild.style.Border
+import io.daio.wild.style.interactionStyle
+import kotlinx.coroutines.runBlocking
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class, ExperimentalWildApi::class)
+class StyleLayerRenderingTest {
+    @Test
+    fun rectangleRoundedAndAlphaModesRenderExpectedPixels() =
+        runComposeUiTest {
+            setContent {
+                Box(Modifier.size(160.dp)) {
+                    TestSurface(
+                        tag = "opaque-rectangle",
+                        shape = RectangleShape,
+                        alpha = 1f,
+                    )
+                    TestSurface(
+                        tag = "opaque-circle",
+                        shape = CircleShape,
+                        alpha = 1f,
+                        modifier = Modifier.align(Alignment.TopEnd),
+                    )
+                    TestSurface(
+                        tag = "alpha-rectangle",
+                        shape = RectangleShape,
+                        alpha = 0.5f,
+                        modifier = Modifier.align(Alignment.BottomStart),
+                    )
+                    TestSurface(
+                        tag = "alpha-circle",
+                        shape = CircleShape,
+                        alpha = 0.5f,
+                        modifier = Modifier.align(Alignment.BottomEnd),
+                    )
+                }
+            }
+            waitForIdle()
+
+            val opaqueRectangle = onNodeWithTag("opaque-rectangle").captureToImage()
+            opaqueRectangle.centerColor().assertCloseTo(Color.Red)
+            opaqueRectangle.cornerColor().assertCloseTo(Color.Red)
+
+            val opaqueCircle = onNodeWithTag("opaque-circle").captureToImage()
+            opaqueCircle.centerColor().assertCloseTo(Color.Red)
+            opaqueCircle.cornerColor().assertCloseTo(Color.Blue)
+
+            val alphaRectangle = onNodeWithTag("alpha-rectangle").captureToImage()
+            alphaRectangle.centerColor().assertCloseTo(RedOverBlue)
+            alphaRectangle.cornerColor().assertCloseTo(RedOverBlue)
+
+            val alphaCircle = onNodeWithTag("alpha-circle").captureToImage()
+            alphaCircle.centerColor().assertCloseTo(RedOverBlue)
+            alphaCircle.cornerColor().assertCloseTo(Color.Blue)
+        }
+
+    @Test
+    fun groupAlphaPreservesOverlappingChildPixels() =
+        runComposeUiTest {
+            setContent {
+                Box(
+                    Modifier
+                        .size(SurfaceSize)
+                        .background(Color.Blue),
+                ) {
+                    Canvas(
+                        Modifier
+                            .fillMaxSize()
+                            .interactionStyle(null) { alpha = 0.5f }
+                            .testTag("overlap"),
+                    ) {
+                        drawRect(Color.Red, size = Size(size.width * 0.75f, size.height))
+                        drawRect(
+                            Color.Red,
+                            topLeft = Offset(size.width * 0.25f, 0f),
+                            size = Size(size.width * 0.75f, size.height),
+                        )
+                    }
+                }
+            }
+            waitForIdle()
+
+            val image = onNodeWithTag("overlap").captureToImage()
+            val pixels = image.toPixelMap()
+            val singleDraw = pixels[image.width / 8, image.height / 2]
+            val overlappingDraws = pixels[image.width / 2, image.height / 2]
+
+            singleDraw.assertCloseTo(RedOverBlue)
+            overlappingDraws.assertCloseTo(singleDraw)
+        }
+
+    @Test
+    fun transitionsBetweenNoLayerAndLayerModesPreserveOutput() =
+        runComposeUiTest {
+            var shape by mutableStateOf<Shape>(RectangleShape)
+            var alpha by mutableStateOf(1f)
+
+            setContent {
+                TestSurface(tag = "transition", shape = shape, alpha = alpha)
+            }
+            waitForIdle()
+
+            onNodeWithTag("transition").captureToImage().run {
+                centerColor().assertCloseTo(Color.Red)
+                cornerColor().assertCloseTo(Color.Red)
+            }
+
+            runOnIdle {
+                shape = CircleShape
+                alpha = 0.5f
+            }
+            waitForIdle()
+
+            onNodeWithTag("transition").captureToImage().run {
+                centerColor().assertCloseTo(RedOverBlue)
+                cornerColor().assertCloseTo(Color.Blue)
+            }
+
+            runOnIdle {
+                shape = RectangleShape
+                alpha = 1f
+            }
+            waitForIdle()
+
+            onNodeWithTag("transition").captureToImage().run {
+                centerColor().assertCloseTo(Color.Red)
+                cornerColor().assertCloseTo(Color.Red)
+            }
+        }
+
+    @Test
+    fun focusAndPressScaleRenderAtDeterministicSizes() =
+        runComposeUiTest {
+            val interactionSource = MutableInteractionSource()
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(SurfaceSize)
+                            .background(Color.Blue)
+                            .testTag("scale-root"),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        Modifier
+                            .size(24.dp)
+                            .interactionStyle(interactionSource) {
+                                color = Color.Red
+                                scale =
+                                    when {
+                                        pressed -> 0.5f
+                                        focused -> 0.75f
+                                        else -> 1f
+                                    }
+                                scaleAnimationSpec = snap()
+                            },
+                    )
+                }
+            }
+            waitForIdle()
+
+            val defaultWidth = onNodeWithTag("scale-root").captureToImage().redWidth()
+
+            lateinit var focus: FocusInteraction.Focus
+            runBlocking {
+                focus = FocusInteraction.Focus()
+                interactionSource.emit(focus)
+            }
+            waitForIdle()
+            val focusedWidth = onNodeWithTag("scale-root").captureToImage().redWidth()
+
+            lateinit var press: PressInteraction.Press
+            runBlocking {
+                press = PressInteraction.Press(Offset.Zero)
+                interactionSource.emit(press)
+            }
+            waitForIdle()
+            val pressedWidth = onNodeWithTag("scale-root").captureToImage().redWidth()
+
+            assertTrue(defaultWidth > focusedWidth)
+            assertTrue(focusedWidth > pressedWidth)
+
+            runBlocking {
+                interactionSource.emit(PressInteraction.Release(press))
+                interactionSource.emit(FocusInteraction.Unfocus(focus))
+            }
+        }
+
+    @Test
+    fun borderInsetsRemainOutsideTheClippedSurfaceWhenRequested() =
+        runComposeUiTest {
+            setContent {
+                Box(Modifier.size(80.dp)) {
+                    BorderSurface(
+                        tag = "outside-border",
+                        inset = 3.dp,
+                    )
+                    BorderSurface(
+                        tag = "inside-border",
+                        inset = -3.dp,
+                        modifier = Modifier.align(Alignment.TopEnd),
+                    )
+                }
+            }
+            waitForIdle()
+
+            val outsideBorder = onNodeWithTag("outside-border").captureToImage()
+            val insideBorder = onNodeWithTag("inside-border").captureToImage()
+
+            assertTrue(outsideBorder.countYellowOutsideChildBounds() > 0)
+            assertEquals(0, insideBorder.countYellowOutsideChildBounds())
+        }
+
+    @Test
+    fun nestedStyledComponentsKeepIndependentClipAndColor() =
+        runComposeUiTest {
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(SurfaceSize)
+                            .background(Color.Blue)
+                            .testTag("nested"),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(32.dp)
+                                .interactionStyle(null) {
+                                    color = Color.Red
+                                    shape = CircleShape
+                                },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            Modifier
+                                .size(12.dp)
+                                .interactionStyle(null) {
+                                    color = Color.Green
+                                    shape = RectangleShape
+                                },
+                        )
+                    }
+                }
+            }
+            waitForIdle()
+
+            val image = onNodeWithTag("nested").captureToImage()
+            val pixels = image.toPixelMap()
+            pixels[image.width / 2, image.height / 2].assertCloseTo(Color.Green)
+            pixels[image.width / 2, image.height / 8].assertCloseTo(Color.Red)
+            image.cornerColor().assertCloseTo(Color.Blue)
+        }
+
+    @Composable
+    private fun TestSurface(
+        tag: String,
+        shape: Shape,
+        alpha: Float,
+        modifier: Modifier = Modifier,
+    ) {
+        Box(
+            modifier =
+                modifier
+                    .size(SurfaceSize)
+                    .background(Color.Blue)
+                    .testTag(tag),
+        ) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .interactionStyle(null) {
+                        this.shape = shape
+                        this.alpha = alpha
+                    }
+                    .background(Color.Red),
+            )
+        }
+    }
+
+    @Composable
+    private fun BorderSurface(
+        tag: String,
+        inset: Dp,
+        modifier: Modifier = Modifier,
+    ) {
+        Box(
+            modifier =
+                modifier
+                    .size(SurfaceSize)
+                    .background(Color.Blue)
+                    .testTag(tag),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                Modifier
+                    .size(24.dp)
+                    .interactionStyle(null) {
+                        color = Color.Red
+                        shape = CircleShape
+                        border = Border(width = 2.dp, color = Color.Yellow, inset = inset)
+                    },
+            )
+        }
+    }
+
+    private fun ImageBitmap.centerColor(): Color = toPixelMap()[width / 2, height / 2]
+
+    private fun ImageBitmap.cornerColor(): Color = toPixelMap()[1, 1]
+
+    private fun ImageBitmap.redWidth(): Int {
+        val pixels = toPixelMap()
+        val y = height / 2
+        return (0 until width).count { x -> pixels[x, y].isCloseTo(Color.Red) }
+    }
+
+    private fun ImageBitmap.countYellowOutsideChildBounds(): Int {
+        val pixels = toPixelMap()
+        val childStartX = (width * 0.2f).toInt()
+        val childEndX = (width * 0.8f).toInt()
+        val childStartY = (height * 0.2f).toInt()
+        val childEndY = (height * 0.8f).toInt()
+        var count = 0
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val outsideChild =
+                    x < childStartX || x >= childEndX || y < childStartY || y >= childEndY
+                if (outsideChild && pixels[x, y].isCloseTo(Color.Yellow)) count++
+            }
+        }
+        return count
+    }
+
+    private fun Color.assertCloseTo(expected: Color) {
+        assertTrue(
+            isCloseTo(expected),
+            "Expected $expected but was $this",
+        )
+    }
+
+    private fun Color.isCloseTo(
+        expected: Color,
+        tolerance: Float = 0.04f,
+    ): Boolean =
+        abs(red - expected.red) <= tolerance &&
+            abs(green - expected.green) <= tolerance &&
+            abs(blue - expected.blue) <= tolerance &&
+            abs(alpha - expected.alpha) <= tolerance
+
+    private companion object {
+        val SurfaceSize = 40.dp
+        val RedOverBlue = Color(red = 0.5f, green = 0f, blue = 0.5f)
+    }
+}


### PR DESCRIPTION
## Summary

- Skip the scale graphics layer when animated scale is `1f` and z-index is `0f`.
- Skip the shape graphics layer for opaque `RectangleShape` surfaces.
- Replace unconditional shape `Offscreen` compositing with `Auto`, allowing Compose to isolate only when required.
- Add predicate coverage for no-op and layer-required states.

This addresses [THE-212](https://linear.app/the-good-egg-studio/issue/THE-212/skip-no-op-layers-and-consolidate-scaleshape-compositing-where-safe).

## Validation

- `./gradlew :style:jvmTest`
- `./gradlew :style:spotlessCheck`

The unified interaction-style node prototype and expanded benchmark evidence remain in THE-217/THE-222 scope.