### PR TITLE
perf: optimize scale animation hot path

### DIFF
--- a/style/src/commonMain/kotlin/io/daio/wild/style/Scale.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Scale.kt
@@ -15,6 +15,10 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 
+private val DefaultScaleAnimationEasing = CubicBezierEasing(0f, 0f, 0.2f, 1f)
+private val PressedScaleAnimationSpec = tween<Float>(durationMillis = 120, easing = DefaultScaleAnimationEasing)
+private val RestingScaleAnimationSpec = tween<Float>(durationMillis = 300, easing = DefaultScaleAnimationEasing)
+
 @Immutable
 data class Scale(
     val scale: Float = 1f,
@@ -122,15 +126,11 @@ fun defaultScaleAnimationSpec(
     focused: Boolean,
     hovered: Boolean,
 ): TweenSpec<Float> =
-    tween(
-        durationMillis =
-            when {
-                (focused || hovered) && !pressed -> 300
-                pressed -> 120
-                else -> 300
-            },
-        easing = CubicBezierEasing(0f, 0f, 0.2f, 1f),
-    )
+    when {
+        pressed -> PressedScaleAnimationSpec
+        focused || hovered -> RestingScaleAnimationSpec
+        else -> RestingScaleAnimationSpec
+    }
 
 /**
  * Contains default [Scale] presets for common interaction patterns.

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -65,7 +65,7 @@ internal class ScaleLayoutModifier(
     Modifier.Node(),
     StyleScopeChildNode {
     private var scaleState = AnimationState(initialValue = scale)
-    internal val animatedScaleForTest: Float
+    internal val animatedScale: Float
         get() = scaleState.value
 
     /**

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -132,7 +132,6 @@ internal class ScaleLayoutModifier(
         if (
             !animationRequestCoalescer.shouldAnimate(
                 scale = scale,
-                zIndex = zIndex,
                 animationSpec = animationSpec,
                 focused = focused,
                 pressed = pressed,
@@ -213,7 +212,6 @@ internal class ScaleAnimationRequestCoalescer {
 
     fun shouldAnimate(
         scale: Float,
-        zIndex: Float,
         animationSpec: AnimationSpec<Float>? = null,
         focused: Boolean = false,
         pressed: Boolean = false,

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.Constraints
 import io.daio.wild.style.StyleScope
 import io.daio.wild.style.defaultScaleAnimationSpec
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
 /**
@@ -65,8 +64,9 @@ internal class ScaleLayoutModifier(
 ) : LayoutModifierNode,
     Modifier.Node(),
     StyleScopeChildNode {
-    private val zIndexState = AnimationState(initialValue = zIndex)
-    private val scaleState = AnimationState(initialValue = scale)
+    private var scaleState = AnimationState(initialValue = scale)
+    internal val animatedScaleForTest: Float
+        get() = scaleState.value
 
     /**
      * Invalidation is handled by [updateScale]
@@ -75,6 +75,8 @@ internal class ScaleLayoutModifier(
         get() = false
 
     private var updateJob: Job? = null
+    internal val isScaleAnimationRunningForTest: Boolean
+        get() = updateJob?.isActive == true
     private val animationRequestCoalescer = ScaleAnimationRequestCoalescer()
 
     override fun onAttach() {
@@ -85,6 +87,7 @@ internal class ScaleLayoutModifier(
         updateJob?.cancel()
         updateJob = null
         animationRequestCoalescer.reset()
+        scaleState = AnimationState(initialValue = 1f)
         scale = 1f
         zIndex = 0f
         customAnimationSpec = null
@@ -120,8 +123,14 @@ internal class ScaleLayoutModifier(
         hovered: Boolean,
         animationSpec: AnimationSpec<Float>? = customAnimationSpec,
     ) {
-        val animationRequest =
-            scaleAnimationRequest(
+        this.scale = scale
+        if (this.zIndex != zIndex) {
+            this.zIndex = zIndex
+            invalidatePlacement()
+        }
+
+        if (
+            !animationRequestCoalescer.shouldAnimate(
                 scale = scale,
                 zIndex = zIndex,
                 animationSpec = animationSpec,
@@ -129,30 +138,25 @@ internal class ScaleLayoutModifier(
                 pressed = pressed,
                 hovered = hovered,
             )
+        ) {
+            return
+        }
 
-        this.scale = scale
-        this.zIndex = zIndex
-
-        if (!animationRequestCoalescer.shouldAnimate(animationRequest)) return
+        val effectiveAnimationSpec =
+            animationSpec
+                ?: defaultScaleAnimationSpec(
+                    focused = focused,
+                    pressed = pressed,
+                    hovered = hovered,
+                )
 
         updateJob?.cancel()
         updateJob =
             coroutineScope.launch {
                 try {
-                    joinAll(
-                        launch { zIndexState.animateTo(zIndex) },
-                        launch {
-                            scaleState.animateTo(
-                                targetValue = scale,
-                                animationSpec =
-                                    animationSpec
-                                        ?: defaultScaleAnimationSpec(
-                                            focused = focused,
-                                            pressed = pressed,
-                                            hovered = hovered,
-                                        ),
-                            )
-                        },
+                    scaleState.animateTo(
+                        targetValue = scale,
+                        animationSpec = effectiveAnimationSpec,
                     )
                 } finally {
                     invalidatePlacement()
@@ -167,9 +171,8 @@ internal class ScaleLayoutModifier(
         val placeable = measurable.measure(constraints)
         return layout(placeable.width, placeable.height) {
             val animatedScale = scaleState.value
-            val animatedZIndex = zIndexState.value
-            if (needsScaleLayer(animatedScale, animatedZIndex)) {
-                placeable.placeWithLayer(0, 0, zIndex = animatedZIndex) {
+            if (needsScaleLayer(animatedScale, zIndex)) {
+                placeable.placeWithLayer(0, 0, zIndex = zIndex) {
                     scaleX = animatedScale
                     scaleY = animatedScale
                 }
@@ -198,63 +201,79 @@ internal fun needsScaleLayer(
     zIndex: Float,
 ): Boolean = animatedScale != 1f || zIndex != 0f
 
-internal data class ScaleAnimationRequest(
-    val scale: Float,
-    val zIndex: Float,
-    val animationSpecKey: ScaleAnimationSpecKey,
-)
-
-internal data class ScaleAnimationSpecKey(
-    val animationSpec: AnimationSpec<Float>,
-)
+internal enum class ScaleDefaultAnimationSpecKind {
+    Pressed,
+    Resting,
+}
 
 internal class ScaleAnimationRequestCoalescer {
-    private var lastAnimationRequest: ScaleAnimationRequest? = null
+    private var lastScale: Float? = null
+    private var lastZIndex: Float? = null
+    private var lastCustomAnimationSpec: AnimationSpec<Float>? = null
+    private var lastDefaultAnimationSpecKind: ScaleDefaultAnimationSpecKind? = null
 
-    fun shouldAnimate(animationRequest: ScaleAnimationRequest): Boolean {
-        if (animationRequest == lastAnimationRequest) return false
+    fun shouldAnimate(
+        scale: Float,
+        zIndex: Float,
+        animationSpec: AnimationSpec<Float>? = null,
+        focused: Boolean = false,
+        pressed: Boolean = false,
+        hovered: Boolean = false,
+    ): Boolean {
+        val defaultAnimationSpecKind =
+            defaultAnimationSpecKind(
+                pressed = pressed,
+                focused = focused,
+                hovered = hovered,
+            )
+        val shouldAnimate =
+            lastScale == null ||
+                scale != lastScale ||
+                hasAnimationSpecChanged(
+                    animationSpec = animationSpec,
+                    defaultAnimationSpecKind = defaultAnimationSpecKind,
+                )
 
-        lastAnimationRequest = animationRequest
-        return true
+        lastScale = scale
+        lastZIndex = zIndex
+        lastCustomAnimationSpec = animationSpec
+        lastDefaultAnimationSpecKind =
+            if (animationSpec == null) {
+                defaultAnimationSpecKind
+            } else {
+                null
+            }
+
+        return shouldAnimate
     }
 
     fun reset() {
-        lastAnimationRequest = null
+        lastScale = null
+        lastZIndex = null
+        lastCustomAnimationSpec = null
+        lastDefaultAnimationSpecKind = null
     }
+
+    private fun hasAnimationSpecChanged(
+        animationSpec: AnimationSpec<Float>?,
+        defaultAnimationSpecKind: ScaleDefaultAnimationSpecKind,
+    ): Boolean =
+        when {
+            animationSpec != null && lastCustomAnimationSpec != null ->
+                animationSpec !== lastCustomAnimationSpec && animationSpec != lastCustomAnimationSpec
+            animationSpec == null && lastCustomAnimationSpec == null ->
+                defaultAnimationSpecKind != lastDefaultAnimationSpecKind
+            else -> true
+        }
+
+    private fun defaultAnimationSpecKind(
+        pressed: Boolean,
+        focused: Boolean,
+        hovered: Boolean,
+    ): ScaleDefaultAnimationSpecKind =
+        when {
+            pressed -> ScaleDefaultAnimationSpecKind.Pressed
+            focused || hovered -> ScaleDefaultAnimationSpecKind.Resting
+            else -> ScaleDefaultAnimationSpecKind.Resting
+        }
 }
-
-internal fun scaleAnimationRequest(
-    scale: Float,
-    zIndex: Float,
-    animationSpec: AnimationSpec<Float>?,
-    focused: Boolean,
-    pressed: Boolean,
-    hovered: Boolean,
-): ScaleAnimationRequest =
-    ScaleAnimationRequest(
-        scale = scale,
-        zIndex = zIndex,
-        animationSpecKey =
-            scaleAnimationSpecKey(
-                animationSpec = animationSpec,
-                focused = focused,
-                pressed = pressed,
-                hovered = hovered,
-            ),
-    )
-
-internal fun scaleAnimationSpecKey(
-    animationSpec: AnimationSpec<Float>?,
-    focused: Boolean,
-    pressed: Boolean,
-    hovered: Boolean,
-): ScaleAnimationSpecKey =
-    ScaleAnimationSpecKey(
-        animationSpec =
-            animationSpec
-                ?: defaultScaleAnimationSpec(
-                    focused = focused,
-                    pressed = pressed,
-                    hovered = hovered,
-                ),
-    )

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -208,7 +208,6 @@ internal enum class ScaleDefaultAnimationSpecKind {
 
 internal class ScaleAnimationRequestCoalescer {
     private var lastScale: Float? = null
-    private var lastZIndex: Float? = null
     private var lastCustomAnimationSpec: AnimationSpec<Float>? = null
     private var lastDefaultAnimationSpecKind: ScaleDefaultAnimationSpecKind? = null
 
@@ -235,7 +234,6 @@ internal class ScaleAnimationRequestCoalescer {
                 )
 
         lastScale = scale
-        lastZIndex = zIndex
         lastCustomAnimationSpec = animationSpec
         lastDefaultAnimationSpecKind =
             if (animationSpec == null) {
@@ -249,7 +247,6 @@ internal class ScaleAnimationRequestCoalescer {
 
     fun reset() {
         lastScale = null
-        lastZIndex = null
         lastCustomAnimationSpec = null
         lastDefaultAnimationSpecKind = null
     }

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -225,7 +225,7 @@ class ScaleAnimationRequestTest {
                     ),
                 )
             }
-            waitUntil { node.isScaleAnimationRunningForTest && node.animatedScaleForTest > 1f }
+            waitUntil { node.isScaleAnimationRunningForTest && node.animatedScale > 1f }
 
             runOnIdle {
                 node.onReset()
@@ -235,7 +235,7 @@ class ScaleAnimationRequestTest {
             assertFalse(node.isScaleAnimationRunningForTest)
             assertEquals(1f, node.scale)
             assertEquals(0f, node.zIndex)
-            assertEquals(1f, node.animatedScaleForTest)
+            assertEquals(1f, node.animatedScale)
 
             runOnIdle {
                 node.updateStyle(
@@ -271,14 +271,14 @@ class ScaleAnimationRequestTest {
             runOnIdle {
                 node.updateStyle(testStyleScope(scale = 1.2f, animationSpec = slowSpec))
             }
-            waitUntil { node.isScaleAnimationRunningForTest && node.animatedScaleForTest > 1f }
+            waitUntil { node.isScaleAnimationRunningForTest && node.animatedScale > 1f }
 
             runOnIdle { contentKey = 1 }
             waitForIdle()
 
             assertEquals(1f, node.scale)
             assertEquals(0f, node.zIndex)
-            assertEquals(1f, node.animatedScaleForTest)
+            assertEquals(1f, node.animatedScale)
             assertFalse(node.isScaleAnimationRunningForTest)
 
             runOnIdle {

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -266,9 +266,7 @@ private class PlacementRecorder {
     var count: Int = 0
 }
 
-private fun Modifier.scaleLayoutForTest(
-    onNode: (ScaleLayoutModifier) -> Unit,
-): Modifier = this then TestScaleLayoutElement(onNode)
+private fun Modifier.scaleLayoutForTest(onNode: (ScaleLayoutModifier) -> Unit): Modifier = this then TestScaleLayoutElement(onNode)
 
 private data class TestScaleLayoutElement(
     private val onNode: (ScaleLayoutModifier) -> Unit,

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -55,34 +55,34 @@ class ScaleAnimationRequestTest {
     fun coalescerAnimatesFirstRequest() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f))
     }
 
     @Test
     fun coalescerSkipsMatchingRequest() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+        coalescer.shouldAnimate(scale = 1.1f)
 
-        assertFalse(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
+        assertFalse(coalescer.shouldAnimate(scale = 1.1f))
     }
 
     @Test
     fun coalescerAnimatesChangedScale() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+        coalescer.shouldAnimate(scale = 1.1f)
 
-        assertTrue(coalescer.shouldAnimate(scale = 1.2f, zIndex = 0.5f))
+        assertTrue(coalescer.shouldAnimate(scale = 1.2f))
     }
 
     @Test
     fun coalescerAnimatesWhenPressedDefaultChanges() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+        coalescer.shouldAnimate(scale = 1.1f)
 
-        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f, pressed = true))
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f, pressed = true))
     }
 
     @Test
@@ -91,14 +91,12 @@ class ScaleAnimationRequestTest {
 
         coalescer.shouldAnimate(
             scale = 1.1f,
-            zIndex = 0.5f,
             focused = true,
         )
 
         assertFalse(
             coalescer.shouldAnimate(
                 scale = 1.1f,
-                zIndex = 0.5f,
                 hovered = true,
             ),
         )
@@ -110,14 +108,12 @@ class ScaleAnimationRequestTest {
 
         coalescer.shouldAnimate(
             scale = 1.1f,
-            zIndex = 0.5f,
             animationSpec = tween(durationMillis = 100),
         )
 
         assertFalse(
             coalescer.shouldAnimate(
                 scale = 1.1f,
-                zIndex = 0.5f,
                 animationSpec = tween(durationMillis = 100),
             ),
         )
@@ -127,12 +123,11 @@ class ScaleAnimationRequestTest {
     fun coalescerAnimatesWhenChangingBetweenDefaultAndCustomSpecs() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+        coalescer.shouldAnimate(scale = 1.1f)
 
         assertTrue(
             coalescer.shouldAnimate(
                 scale = 1.1f,
-                zIndex = 0.5f,
                 animationSpec = tween(durationMillis = 100),
             ),
         )
@@ -144,31 +139,20 @@ class ScaleAnimationRequestTest {
 
         coalescer.shouldAnimate(
             scale = 1.1f,
-            zIndex = 0.5f,
             animationSpec = tween(durationMillis = 100),
         )
 
-        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
-    }
-
-    @Test
-    fun coalescerTracksZIndexChangesWithoutRestartingScaleAnimation() {
-        val coalescer = ScaleAnimationRequestCoalescer()
-
-        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0f)
-
-        assertFalse(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
-        assertFalse(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0f))
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f))
     }
 
     @Test
     fun coalescerAnimatesMatchingRequestAfterReset() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+        coalescer.shouldAnimate(scale = 1.1f)
         coalescer.reset()
 
-        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f))
     }
 
     @Test

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -2,156 +2,303 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.style.modifiers
 
-import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import io.daio.wild.foundation.ExperimentalWildApi
+import io.daio.wild.style.DefaultStyleScope
+import io.daio.wild.style.StyleScope
+import io.daio.wild.style.defaultScaleAnimationSpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalTestApi::class, ExperimentalWildApi::class)
 class ScaleAnimationRequestTest {
     @Test
-    fun matchingDefaultRequestsAreEqual() {
-        val first = request(scale = 1.1f, zIndex = 0.5f)
-        val second = request(scale = 1.1f, zIndex = 0.5f)
+    fun defaultRestingSpecIsCachedWithExpectedDurationAndEasing() {
+        val resting = defaultScaleAnimationSpec(pressed = false, focused = false, hovered = false)
+        val focused = defaultScaleAnimationSpec(pressed = false, focused = true, hovered = false)
+        val hovered = defaultScaleAnimationSpec(pressed = false, focused = false, hovered = true)
 
-        assertEquals(first, second)
+        assertSame(resting, focused)
+        assertSame(resting, hovered)
+        assertEquals(300, resting.durationMillis)
+        assertEquals(CubicBezierEasing(0f, 0f, 0.2f, 1f), resting.easing)
     }
 
     @Test
-    fun changedScaleCreatesDifferentRequest() {
-        val first = request(scale = 1.1f, zIndex = 0.5f)
-        val second = request(scale = 1.2f, zIndex = 0.5f)
+    fun defaultPressedSpecIsCachedWithExpectedDurationAndEasing() {
+        val pressed = defaultScaleAnimationSpec(pressed = true, focused = false, hovered = false)
+        val pressedAndFocused =
+            defaultScaleAnimationSpec(pressed = true, focused = true, hovered = false)
+        val pressedAndHovered =
+            defaultScaleAnimationSpec(pressed = true, focused = false, hovered = true)
 
-        assertNotEquals(first, second)
-    }
-
-    @Test
-    fun changedZIndexCreatesDifferentRequest() {
-        val first = request(scale = 1.1f, zIndex = 0.5f)
-        val second = request(scale = 1.1f, zIndex = 0f)
-
-        assertNotEquals(first, second)
-    }
-
-    @Test
-    fun defaultPressedAndNonPressedRequestsAreDifferent() {
-        val first = request(scale = 1.1f, zIndex = 0.5f)
-        val second = request(scale = 1.1f, zIndex = 0.5f, pressed = true)
-
-        assertNotEquals(first, second)
-    }
-
-    @Test
-    fun defaultFocusedAndHoveredRequestsWithSameTargetAreEqual() {
-        val focused =
-            request(
-                scale = 1.1f,
-                zIndex = 0.5f,
-                focused = true,
-            )
-        val hovered =
-            request(
-                scale = 1.1f,
-                zIndex = 0.5f,
-                hovered = true,
-            )
-
-        assertEquals(focused, hovered)
-    }
-
-    @Test
-    fun matchingCustomSpecRequestsAreEqual() {
-        val spec = tween<Float>(durationMillis = 100)
-        val first = request(scale = 1.1f, zIndex = 0.5f, animationSpec = spec)
-        val second = request(scale = 1.1f, zIndex = 0.5f, animationSpec = spec)
-
-        assertEquals(first, second)
-    }
-
-    @Test
-    fun differentCustomSpecRequestsAreDifferent() {
-        val first =
-            request(
-                scale = 1.1f,
-                zIndex = 0.5f,
-                animationSpec = tween(durationMillis = 100),
-            )
-        val second =
-            request(
-                scale = 1.1f,
-                zIndex = 0.5f,
-                animationSpec = tween(durationMillis = 200),
-            )
-
-        assertNotEquals(first, second)
-    }
-
-    @Test
-    fun customAndDefaultRequestsAreDifferent() {
-        val custom =
-            request(
-                scale = 1.1f,
-                zIndex = 0.5f,
-                animationSpec = tween(durationMillis = 300),
-            )
-        val default = request(scale = 1.1f, zIndex = 0.5f)
-
-        assertNotEquals(custom, default)
+        assertSame(pressed, pressedAndFocused)
+        assertSame(pressed, pressedAndHovered)
+        assertEquals(120, pressed.durationMillis)
+        assertEquals(CubicBezierEasing(0f, 0f, 0.2f, 1f), pressed.easing)
     }
 
     @Test
     fun coalescerAnimatesFirstRequest() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        assertTrue(coalescer.shouldAnimate(request(scale = 1.1f, zIndex = 0.5f)))
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
     }
 
     @Test
     fun coalescerSkipsMatchingRequest() {
         val coalescer = ScaleAnimationRequestCoalescer()
-        val request = request(scale = 1.1f, zIndex = 0.5f)
 
-        coalescer.shouldAnimate(request)
+        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
 
-        assertFalse(coalescer.shouldAnimate(request))
+        assertFalse(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
     }
 
     @Test
-    fun coalescerAnimatesChangedRequest() {
+    fun coalescerAnimatesChangedScale() {
         val coalescer = ScaleAnimationRequestCoalescer()
 
-        coalescer.shouldAnimate(request(scale = 1.1f, zIndex = 0.5f))
+        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
 
-        assertTrue(coalescer.shouldAnimate(request(scale = 1.2f, zIndex = 0.5f)))
+        assertTrue(coalescer.shouldAnimate(scale = 1.2f, zIndex = 0.5f))
+    }
+
+    @Test
+    fun coalescerAnimatesWhenPressedDefaultChanges() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f, pressed = true))
+    }
+
+    @Test
+    fun coalescerSkipsFocusedAndHoveredDefaultRequestsWithSameTarget() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(
+            scale = 1.1f,
+            zIndex = 0.5f,
+            focused = true,
+        )
+
+        assertFalse(
+            coalescer.shouldAnimate(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                hovered = true,
+            ),
+        )
+    }
+
+    @Test
+    fun coalescerSkipsEqualCustomSpecRequests() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(
+            scale = 1.1f,
+            zIndex = 0.5f,
+            animationSpec = tween(durationMillis = 100),
+        )
+
+        assertFalse(
+            coalescer.shouldAnimate(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                animationSpec = tween(durationMillis = 100),
+            ),
+        )
+    }
+
+    @Test
+    fun coalescerAnimatesWhenChangingBetweenDefaultAndCustomSpecs() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
+
+        assertTrue(
+            coalescer.shouldAnimate(
+                scale = 1.1f,
+                zIndex = 0.5f,
+                animationSpec = tween(durationMillis = 100),
+            ),
+        )
+    }
+
+    @Test
+    fun coalescerAnimatesWhenChangingBetweenCustomAndDefaultSpecs() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(
+            scale = 1.1f,
+            zIndex = 0.5f,
+            animationSpec = tween(durationMillis = 100),
+        )
+
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
+    }
+
+    @Test
+    fun coalescerTracksZIndexChangesWithoutRestartingScaleAnimation() {
+        val coalescer = ScaleAnimationRequestCoalescer()
+
+        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0f)
+
+        assertFalse(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
+        assertFalse(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0f))
     }
 
     @Test
     fun coalescerAnimatesMatchingRequestAfterReset() {
         val coalescer = ScaleAnimationRequestCoalescer()
-        val request = request(scale = 1.1f, zIndex = 0.5f)
 
-        coalescer.shouldAnimate(request)
+        coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f)
         coalescer.reset()
 
-        assertTrue(coalescer.shouldAnimate(request))
+        assertTrue(coalescer.shouldAnimate(scale = 1.1f, zIndex = 0.5f))
     }
 
-    private fun request(
-        scale: Float,
-        zIndex: Float,
-        focused: Boolean = false,
-        pressed: Boolean = false,
-        hovered: Boolean = false,
-        animationSpec: AnimationSpec<Float>? = null,
-    ): ScaleAnimationRequest =
-        scaleAnimationRequest(
-            scale = scale,
-            zIndex = zIndex,
-            animationSpec = animationSpec,
+    @Test
+    fun zIndexChangeInvalidatesPlacementWithoutStartingScaleAnimationJob() =
+        runComposeUiTest {
+            val recorder = PlacementRecorder()
+            lateinit var node: ScaleLayoutModifier
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(8.dp)
+                            .scaleLayoutForTest { node = it }
+                            .onPlaced { recorder.count++ },
+                )
+            }
+            waitForIdle()
+
+            runOnIdle {
+                node.updateStyle(testStyleScope(scale = 1f))
+            }
+            waitForIdle()
+            assertFalse(node.isScaleAnimationRunningForTest)
+            val placementsAfterBaseline = recorder.count
+
+            runOnIdle {
+                node.updateStyle(
+                    testStyleScope(
+                        scale = 1f,
+                        focused = true,
+                    ),
+                )
+            }
+            waitForIdle()
+
+            assertEquals(placementsAfterBaseline + 1, recorder.count)
+            assertFalse(node.isScaleAnimationRunningForTest)
+        }
+
+    @Test
+    fun resetClearsStateAndCancelsScaleAnimationJob() =
+        runComposeUiTest {
+            lateinit var node: ScaleLayoutModifier
+            val slowSpec =
+                tween<Float>(
+                    durationMillis = 10_000,
+                    easing = LinearEasing,
+                )
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(8.dp)
+                            .scaleLayoutForTest { node = it },
+                )
+            }
+            waitForIdle()
+
+            runOnIdle {
+                node.updateStyle(
+                    testStyleScope(
+                        scale = 1.2f,
+                        animationSpec = slowSpec,
+                    ),
+                )
+            }
+            waitUntil { node.isScaleAnimationRunningForTest && node.animatedScaleForTest > 1f }
+
+            runOnIdle {
+                node.onReset()
+            }
+            waitForIdle()
+
+            assertFalse(node.isScaleAnimationRunningForTest)
+            assertEquals(1f, node.scale)
+            assertEquals(0f, node.zIndex)
+            assertEquals(1f, node.animatedScaleForTest)
+
+            runOnIdle {
+                node.updateStyle(
+                    testStyleScope(
+                        scale = 1.2f,
+                        animationSpec = slowSpec,
+                    ),
+                )
+            }
+
+            assertTrue(node.isScaleAnimationRunningForTest)
+        }
+}
+
+private class PlacementRecorder {
+    var count: Int = 0
+}
+
+private fun Modifier.scaleLayoutForTest(
+    onNode: (ScaleLayoutModifier) -> Unit,
+): Modifier = this then TestScaleLayoutElement(onNode)
+
+private data class TestScaleLayoutElement(
+    private val onNode: (ScaleLayoutModifier) -> Unit,
+) : androidx.compose.ui.node.ModifierNodeElement<ScaleLayoutModifier>() {
+    override fun create(): ScaleLayoutModifier = ScaleLayoutModifier(zIndex = 0f, scale = 1f).also(onNode)
+
+    override fun update(node: ScaleLayoutModifier) {
+        onNode(node)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "TestScaleLayoutElement"
+    }
+}
+
+private fun testStyleScope(
+    scale: Float,
+    focused: Boolean = false,
+    hovered: Boolean = false,
+    pressed: Boolean = false,
+    animationSpec: androidx.compose.animation.core.AnimationSpec<Float>? = null,
+): StyleScope =
+    DefaultStyleScope().apply {
+        this.scale = scale
+        this.scaleAnimationSpec = animationSpec
+        updateState(
+            enabled = true,
             focused = focused,
+            selected = false,
             pressed = pressed,
             hovered = hovered,
         )
-}
+    }

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/ScaleAnimationRequestTest.kt
@@ -7,6 +7,10 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.ReusableContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.InspectorInfo
@@ -242,6 +246,44 @@ class ScaleAnimationRequestTest {
                 )
             }
 
+            assertTrue(node.isScaleAnimationRunningForTest)
+        }
+
+    @Test
+    fun reusableContentResetsAndReusesScaleNode() =
+        runComposeUiTest {
+            var contentKey by mutableStateOf(0)
+            lateinit var node: ScaleLayoutModifier
+            val slowSpec = tween<Float>(durationMillis = 10_000, easing = LinearEasing)
+
+            setContent {
+                ReusableContent(key = contentKey) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(8.dp)
+                                .scaleLayoutForTest { node = it },
+                    )
+                }
+            }
+            waitForIdle()
+
+            runOnIdle {
+                node.updateStyle(testStyleScope(scale = 1.2f, animationSpec = slowSpec))
+            }
+            waitUntil { node.isScaleAnimationRunningForTest && node.animatedScaleForTest > 1f }
+
+            runOnIdle { contentKey = 1 }
+            waitForIdle()
+
+            assertEquals(1f, node.scale)
+            assertEquals(0f, node.zIndex)
+            assertEquals(1f, node.animatedScaleForTest)
+            assertFalse(node.isScaleAnimationRunningForTest)
+
+            runOnIdle {
+                node.updateStyle(testStyleScope(scale = 1.2f, animationSpec = slowSpec))
+            }
             assertTrue(node.isScaleAnimationRunningForTest)
         }
 }


### PR DESCRIPTION
## Summary

- Cache the default pressed/resting scale animation specs and easing.
- Replace scale animation request/key wrappers with scalar coalescing state.
- Apply z-index immediately with placement-only invalidation and run one scale animation coroutine.
- Add coverage for cached specs, coalescing, z-index placement, and reset behavior.

## Why

Scale updates occur on the TV focus hot path. The previous implementation allocated request/spec wrappers and launched separate z-index and scale coroutines for each changed update.

## Validation

- `./gradlew :style:jvmTest`
- `./gradlew :style:spotlessCheck`
- Whole-branch and task-level code review: no Critical or Important findings.
