### PR TITLE
perf: remove composed from styled interaction fast paths (THE-220)

### DIFF
--- a/components/button/build.gradle.kts
+++ b/components/button/build.gradle.kts
@@ -20,6 +20,18 @@ kotlin {
                 api(projects.contentColor)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+            }
+        }
     }
 }
 

--- a/components/button/src/commonMain/kotlin/io/daio/wild/components/button/Button.kt
+++ b/components/button/src/commonMain/kotlin/io/daio/wild/components/button/Button.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -77,6 +78,8 @@ fun Button(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
+    val effectiveInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
     Container(
         modifier =
             modifier
@@ -87,7 +90,7 @@ fun Button(
         onClick = onClick,
         onLongClick = onLongClick,
         onDoubleClick = onDoubleClick,
-        interactionSource = interactionSource,
+        interactionSource = effectiveInteractionSource,
         content = {
             Box(
                 modifier =

--- a/components/button/src/commonTest/kotlin/ButtonInteractionSourceOwnershipTest.kt
+++ b/components/button/src/commonTest/kotlin/ButtonInteractionSourceOwnershipTest.kt
@@ -1,0 +1,139 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.components.button
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.CompositionGroup
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ButtonInteractionSourceOwnershipTest {
+    @Test
+    fun implicitInteractionSourceIsOwnedByButtonAndStableAcrossRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            lateinit var compositionData: CompositionData
+            val ownedSources = mutableListOf<MutableInteractionSource>()
+
+            setContent {
+                generation.intValue
+                compositionData = currentComposer.compositionData
+                Button(
+                    onClick = {},
+                    modifier = Modifier.size(48.dp),
+                ) {}
+            }
+
+            runOnIdle {
+                ownedSources += compositionData.directlyOwnedInteractionSources().single()
+                generation.intValue++
+            }
+            runOnIdle {
+                val sources = compositionData.directlyOwnedInteractionSources()
+                assertEquals(1, sources.size, compositionData.dump())
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                ownedSources += sources.single()
+                assertEquals(2, ownedSources.size)
+                assertSame(ownedSources.first(), ownedSources.last())
+            }
+        }
+
+    @Test
+    fun explicitInteractionSourceDrivesInputAndHasOneSetOfObservers() =
+        runComposeUiTest {
+            val source = CountingMutableInteractionSource()
+            var clickCount = 0
+
+            setContent {
+                Button(
+                    onClick = { clickCount++ },
+                    modifier = Modifier.testTag("button").size(48.dp),
+                    interactionSource = source,
+                ) {}
+            }
+
+            onNodeWithTag("button").performSemanticsAction(SemanticsActions.RequestFocus)
+            onNodeWithTag("button").performClick()
+            waitForIdle()
+
+            runOnIdle {
+                assertEquals(1, clickCount)
+                assertEquals(4, source.subscriptionCount)
+                assertTrue(source.emittedInteractions.any { it is androidx.compose.foundation.interaction.FocusInteraction.Focus })
+            }
+        }
+}
+
+private fun CompositionData.directlyOwnedInteractionSources(): List<MutableInteractionSource> =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.flatMap { group -> group.data.filterIsInstance<MutableInteractionSource>() }
+        ?.distinct()
+        .orEmpty()
+
+private fun CompositionData.firstSourceOwnerGroup(): CompositionGroup? =
+    compositionGroups.firstNotNullOfOrNull { group ->
+        group.takeIf {
+            it.compositionGroups.any { child -> child.data.any { value -> value is MutableInteractionSource } }
+        } ?: group.firstSourceOwnerGroup()
+    }
+
+private fun CompositionData.firstSourceOwnerHasDirectLayoutNode(): Boolean =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.any { group -> group.data.any { value -> value?.let { it::class.simpleName } == "LayoutNode" } }
+        ?: false
+
+private fun CompositionData.dump(depth: Int = 0): String =
+    compositionGroups.joinToString(separator = "\n") { group ->
+        "${"  ".repeat(depth)}${group.sourceInfo} ${group.data.map {
+            it?.let {
+                    value ->
+                value::class.simpleName
+            }
+        }}\n${group.dump(depth + 1)}"
+    }
+
+private class CountingMutableInteractionSource : MutableInteractionSource {
+    private val delegate = MutableInteractionSource()
+
+    var subscriptionCount = 0
+        private set
+
+    val emittedInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+
+    override val interactions: Flow<androidx.compose.foundation.interaction.Interaction> =
+        flow {
+            subscriptionCount++
+            delegate.interactions.collect { interaction -> emit(interaction) }
+        }
+
+    override suspend fun emit(interaction: androidx.compose.foundation.interaction.Interaction) {
+        emittedInteractions += interaction
+        delegate.emit(interaction)
+    }
+
+    override fun tryEmit(interaction: androidx.compose.foundation.interaction.Interaction): Boolean {
+        emittedInteractions += interaction
+        return delegate.tryEmit(interaction)
+    }
+}

--- a/components/button/src/commonTest/kotlin/ButtonInteractionSourceOwnershipTest.kt
+++ b/components/button/src/commonTest/kotlin/ButtonInteractionSourceOwnershipTest.kt
@@ -9,14 +9,18 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import io.daio.wild.content.LocalContentColor
+import io.daio.wild.style.StyleDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.test.Test
@@ -27,6 +31,33 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class ButtonInteractionSourceOwnershipTest {
+    @Test
+    fun implicitInteractionSourceKeepsFocusedContentColorAcrossParentRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            var observedContentColor = Color.Unspecified
+
+            setContent {
+                Button(
+                    onClick = {},
+                    modifier = Modifier.testTag("button-${generation.intValue}").size(48.dp),
+                    style = focusedContentStyle(),
+                ) { observedContentColor = LocalContentColor.current }
+            }
+
+            runOnIdle { assertEquals(UnfocusedContentColor, observedContentColor) }
+            onNodeWithTag("button-0")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+                .assertIsFocused()
+            waitForIdle()
+            runOnIdle { assertEquals(FocusedContentColor, observedContentColor) }
+
+            runOnIdle { generation.intValue++ }
+
+            onNodeWithTag("button-1").assertIsFocused()
+            runOnIdle { assertEquals(FocusedContentColor, observedContentColor) }
+        }
+
     @Test
     fun implicitInteractionSourceIsOwnedByButtonAndStableAcrossRecomposition() =
         runComposeUiTest {
@@ -82,6 +113,18 @@ class ButtonInteractionSourceOwnershipTest {
             }
         }
 }
+
+private val UnfocusedContentColor = Color.Red
+private val FocusedContentColor = Color.Green
+
+private fun focusedContentStyle() =
+    StyleDefaults.style(
+        colors =
+            StyleDefaults.colors(
+                contentColor = UnfocusedContentColor,
+                focusedContentColor = FocusedContentColor,
+            ),
+    )
 
 private fun CompositionData.directlyOwnedInteractionSources(): List<MutableInteractionSource> =
     firstSourceOwnerGroup()

--- a/components/list-item/build.gradle.kts
+++ b/components/list-item/build.gradle.kts
@@ -23,6 +23,13 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
             }
         }
     }

--- a/components/list-item/src/commonMain/kotlin/io/daio/wild/components/listitem/ListItem.kt
+++ b/components/list-item/src/commonMain/kotlin/io/daio/wild/components/listitem/ListItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -57,6 +58,8 @@ fun ListItem(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable () -> Unit,
 ) {
+    val effectiveInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
     Container(
         onClick = onClick,
         modifier =
@@ -66,7 +69,7 @@ fun ListItem(
         enabled = enabled,
         selected = selected,
         style = style,
-        interactionSource = interactionSource,
+        interactionSource = effectiveInteractionSource,
     ) {
         Row(
             modifier =
@@ -115,6 +118,8 @@ fun ListItem(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable () -> Unit,
 ) {
+    val effectiveInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
     Container(
         onClick = onClick,
         modifier =
@@ -124,7 +129,7 @@ fun ListItem(
         enabled = enabled,
         selected = selected,
         style = style,
-        interactionSource = interactionSource,
+        interactionSource = effectiveInteractionSource,
     ) {
         Row(
             modifier =

--- a/components/list-item/src/commonTest/kotlin/ListItemInteractionSourceOwnershipTest.kt
+++ b/components/list-item/src/commonTest/kotlin/ListItemInteractionSourceOwnershipTest.kt
@@ -1,0 +1,161 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.components.listitem
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.CompositionGroup
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalTestApi::class)
+class ListItemInteractionSourceOwnershipTest {
+    @Test
+    fun contentOnlyListItemOwnsStableImplicitInteractionSource() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            lateinit var compositionData: CompositionData
+            val ownedSources = mutableListOf<MutableInteractionSource>()
+
+            setContent {
+                generation.intValue
+                compositionData = currentComposer.compositionData
+                ListItem(
+                    onClick = {},
+                    modifier = Modifier.size(48.dp),
+                ) {}
+            }
+
+            runOnIdle {
+                ownedSources += compositionData.directlyOwnedInteractionSources().single()
+                generation.intValue++
+            }
+            runOnIdle {
+                val sources = compositionData.directlyOwnedInteractionSources()
+                assertEquals(1, sources.size, compositionData.dump())
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                ownedSources += sources.single()
+                assertEquals(2, ownedSources.size)
+                assertSame(ownedSources.first(), ownedSources.last())
+            }
+        }
+
+    @Test
+    fun slottedListItemOwnsStableImplicitInteractionSource() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            lateinit var compositionData: CompositionData
+            val ownedSources = mutableListOf<MutableInteractionSource>()
+
+            setContent {
+                generation.intValue
+                compositionData = currentComposer.compositionData
+                ListItem(
+                    onClick = {},
+                    leadingContent = {},
+                    trailingContent = {},
+                    modifier = Modifier.size(48.dp),
+                ) {}
+            }
+
+            runOnIdle {
+                ownedSources += compositionData.directlyOwnedInteractionSources().single()
+                generation.intValue++
+            }
+            runOnIdle {
+                val sources = compositionData.directlyOwnedInteractionSources()
+                assertEquals(1, sources.size)
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                ownedSources += sources.single()
+                assertEquals(2, ownedSources.size)
+                assertSame(ownedSources.first(), ownedSources.last())
+            }
+        }
+
+    @Test
+    fun contentOnlyListItemPreservesExplicitInteractionSource() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            var clickCount = 0
+            lateinit var compositionData: CompositionData
+
+            setContent {
+                compositionData = currentComposer.compositionData
+                ListItem(
+                    onClick = { clickCount++ },
+                    modifier = Modifier.testTag("content-only-list-item").size(48.dp),
+                    interactionSource = source,
+                ) {}
+            }
+
+            onNodeWithTag("content-only-list-item").performClick()
+            runOnIdle {
+                assertEquals(1, clickCount)
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                assertSame(source, compositionData.directlyOwnedInteractionSources().single())
+            }
+        }
+
+    @Test
+    fun slottedListItemPreservesExplicitInteractionSource() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            var clickCount = 0
+            lateinit var compositionData: CompositionData
+
+            setContent {
+                compositionData = currentComposer.compositionData
+                ListItem(
+                    onClick = { clickCount++ },
+                    leadingContent = {},
+                    trailingContent = {},
+                    modifier = Modifier.testTag("slotted-list-item").size(48.dp),
+                    interactionSource = source,
+                ) {}
+            }
+
+            onNodeWithTag("slotted-list-item").performClick()
+            runOnIdle {
+                assertEquals(1, clickCount)
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                assertSame(source, compositionData.directlyOwnedInteractionSources().single())
+            }
+        }
+}
+
+private fun CompositionData.directlyOwnedInteractionSources(): List<MutableInteractionSource> =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.flatMap { group -> group.data.filterIsInstance<MutableInteractionSource>() }
+        ?.distinct()
+        .orEmpty()
+
+private fun CompositionData.firstSourceOwnerGroup(): CompositionGroup? =
+    compositionGroups.firstNotNullOfOrNull { group ->
+        group.takeIf {
+            it.compositionGroups.any { child -> child.data.any { value -> value is MutableInteractionSource } }
+        } ?: group.firstSourceOwnerGroup()
+    }
+
+private fun CompositionData.firstSourceOwnerHasDirectLayoutNode(): Boolean =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.any { group -> group.data.any { value -> value?.let { it::class.simpleName } == "LayoutNode" } }
+        ?: false
+
+private fun CompositionData.dump(depth: Int = 0): String =
+    compositionGroups.joinToString(separator = "\n") { group ->
+        "${"  ".repeat(depth)}${group.data.map { value -> value?.let { it::class.simpleName } }}\n${group.dump(depth + 1)}"
+    }

--- a/components/list-item/src/commonTest/kotlin/ListItemInteractionSourceOwnershipTest.kt
+++ b/components/list-item/src/commonTest/kotlin/ListItemInteractionSourceOwnershipTest.kt
@@ -9,12 +9,18 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import io.daio.wild.content.LocalContentColor
+import io.daio.wild.style.StyleDefaults
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -22,6 +28,53 @@ import kotlin.test.assertSame
 
 @OptIn(ExperimentalTestApi::class)
 class ListItemInteractionSourceOwnershipTest {
+    @Test
+    fun contentOnlyListItemKeepsFocusedContentColorAcrossParentRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            var observedContentColor = Color.Unspecified
+
+            setContent {
+                ListItem(
+                    onClick = {},
+                    modifier =
+                        Modifier
+                            .testTag("content-only-list-item-${generation.intValue}")
+                            .size(48.dp),
+                    style = focusedContentStyle(),
+                ) { observedContentColor = LocalContentColor.current }
+            }
+
+            assertFocusAndColorSurviveRecomposition(
+                targetTagPrefix = "content-only-list-item",
+                generation = generation,
+                observedContentColor = { observedContentColor },
+            )
+        }
+
+    @Test
+    fun slottedListItemKeepsFocusedContentColorAcrossParentRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            var observedContentColor = Color.Unspecified
+
+            setContent {
+                ListItem(
+                    onClick = {},
+                    leadingContent = {},
+                    trailingContent = {},
+                    modifier = Modifier.testTag("slotted-list-item-${generation.intValue}").size(48.dp),
+                    style = focusedContentStyle(),
+                ) { observedContentColor = LocalContentColor.current }
+            }
+
+            assertFocusAndColorSurviveRecomposition(
+                targetTagPrefix = "slotted-list-item",
+                generation = generation,
+                observedContentColor = { observedContentColor },
+            )
+        }
+
     @Test
     fun contentOnlyListItemOwnsStableImplicitInteractionSource() =
         runComposeUiTest {
@@ -133,6 +186,37 @@ class ListItemInteractionSourceOwnershipTest {
                 assertSame(source, compositionData.directlyOwnedInteractionSources().single())
             }
         }
+}
+
+private val UnfocusedContentColor = Color.Red
+private val FocusedContentColor = Color.Green
+
+private fun focusedContentStyle() =
+    StyleDefaults.style(
+        colors =
+            StyleDefaults.colors(
+                contentColor = UnfocusedContentColor,
+                focusedContentColor = FocusedContentColor,
+            ),
+    )
+
+@OptIn(ExperimentalTestApi::class)
+private fun androidx.compose.ui.test.ComposeUiTest.assertFocusAndColorSurviveRecomposition(
+    targetTagPrefix: String,
+    generation: androidx.compose.runtime.MutableIntState,
+    observedContentColor: () -> Color,
+) {
+    runOnIdle { assertEquals(UnfocusedContentColor, observedContentColor()) }
+    onNodeWithTag("$targetTagPrefix-0")
+        .performSemanticsAction(SemanticsActions.RequestFocus)
+        .assertIsFocused()
+    waitForIdle()
+    runOnIdle { assertEquals(FocusedContentColor, observedContentColor()) }
+
+    runOnIdle { generation.intValue++ }
+
+    onNodeWithTag("$targetTagPrefix-1").assertIsFocused()
+    runOnIdle { assertEquals(FocusedContentColor, observedContentColor()) }
 }
 
 private fun CompositionData.directlyOwnedInteractionSources(): List<MutableInteractionSource> =

--- a/components/toggleable/src/commonMain/kotlin/io/daio/wild/components/toggleable/Toggleable.kt
+++ b/components/toggleable/src/commonMain/kotlin/io/daio/wild/components/toggleable/Toggleable.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -90,6 +91,8 @@ fun Toggleable(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
+    val effectiveInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
     Container(
         onClick = { onCheckedChange(!checked) },
         modifier =
@@ -99,7 +102,7 @@ fun Toggleable(
         enabled = enabled,
         selected = checked,
         style = style,
-        interactionSource = interactionSource,
+        interactionSource = effectiveInteractionSource,
         content = content,
     )
 }
@@ -144,6 +147,8 @@ fun Selectable(
     interactionSource: MutableInteractionSource? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
+    val effectiveInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
     Container(
         onClick = onClick,
         modifier =
@@ -153,7 +158,7 @@ fun Selectable(
         enabled = enabled,
         selected = selected,
         style = style,
-        interactionSource = interactionSource,
+        interactionSource = effectiveInteractionSource,
         content = content,
     )
 }

--- a/components/toggleable/src/commonTest/kotlin/ToggleableInteractionSourceOwnershipTest.kt
+++ b/components/toggleable/src/commonTest/kotlin/ToggleableInteractionSourceOwnershipTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.components.toggleable
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.CompositionGroup
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalTestApi::class)
+class ToggleableInteractionSourceOwnershipTest {
+    @Test
+    fun toggleableOwnsStableImplicitInteractionSource() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            lateinit var compositionData: CompositionData
+            val ownedSources = mutableListOf<MutableInteractionSource>()
+
+            setContent {
+                generation.intValue
+                compositionData = currentComposer.compositionData
+                Toggleable(
+                    checked = false,
+                    onCheckedChange = {},
+                    modifier = Modifier.size(48.dp),
+                ) {}
+            }
+
+            runOnIdle {
+                ownedSources += compositionData.directlyOwnedInteractionSources().single()
+                generation.intValue++
+            }
+            runOnIdle {
+                val sources = compositionData.directlyOwnedInteractionSources()
+                assertEquals(1, sources.size, compositionData.dump())
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                ownedSources += sources.single()
+                assertEquals(2, ownedSources.size)
+                assertSame(ownedSources.first(), ownedSources.last())
+            }
+        }
+
+    @Test
+    fun selectableOwnsStableImplicitInteractionSource() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            lateinit var compositionData: CompositionData
+            val ownedSources = mutableListOf<MutableInteractionSource>()
+
+            setContent {
+                generation.intValue
+                compositionData = currentComposer.compositionData
+                Selectable(
+                    selected = false,
+                    onClick = {},
+                    modifier = Modifier.size(48.dp),
+                ) {}
+            }
+
+            runOnIdle {
+                ownedSources += compositionData.directlyOwnedInteractionSources().single()
+                generation.intValue++
+            }
+            runOnIdle {
+                val sources = compositionData.directlyOwnedInteractionSources()
+                assertEquals(1, sources.size)
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                ownedSources += sources.single()
+                assertEquals(2, ownedSources.size)
+                assertSame(ownedSources.first(), ownedSources.last())
+            }
+        }
+
+    @Test
+    fun explicitInteractionSourceIsPreserved() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            lateinit var compositionData: CompositionData
+
+            setContent {
+                compositionData = currentComposer.compositionData
+                Toggleable(
+                    checked = false,
+                    onCheckedChange = {},
+                    modifier = Modifier.size(48.dp),
+                    interactionSource = source,
+                ) {}
+            }
+
+            runOnIdle {
+                assertFalse(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                assertSame(source, compositionData.directlyOwnedInteractionSources().single())
+            }
+        }
+}
+
+private fun CompositionData.directlyOwnedInteractionSources(): List<MutableInteractionSource> =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.flatMap { group -> group.data.filterIsInstance<MutableInteractionSource>() }
+        ?.distinct()
+        .orEmpty()
+
+private fun CompositionData.firstSourceOwnerGroup(): CompositionGroup? =
+    compositionGroups.firstNotNullOfOrNull { group ->
+        group.takeIf {
+            it.compositionGroups.any { child -> child.data.any { value -> value is MutableInteractionSource } }
+        } ?: group.firstSourceOwnerGroup()
+    }
+
+private fun CompositionData.firstSourceOwnerHasDirectLayoutNode(): Boolean =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.any { group -> group.data.any { value -> value?.let { it::class.simpleName } == "LayoutNode" } }
+        ?: false
+
+private fun CompositionData.dump(depth: Int = 0): String =
+    compositionGroups.joinToString(separator = "\n") { group ->
+        "${"  ".repeat(depth)}${group.data.map { value -> value?.let { it::class.simpleName } }}\n${group.dump(depth + 1)}"
+    }

--- a/components/toggleable/src/commonTest/kotlin/ToggleableInteractionSourceOwnershipTest.kt
+++ b/components/toggleable/src/commonTest/kotlin/ToggleableInteractionSourceOwnershipTest.kt
@@ -9,16 +9,70 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import io.daio.wild.content.LocalContentColor
+import io.daio.wild.style.StyleDefaults
+import kotlinx.coroutines.flow.Flow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class ToggleableInteractionSourceOwnershipTest {
+    @Test
+    fun toggleableKeepsFocusedContentColorAcrossParentRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            var observedContentColor = Color.Unspecified
+
+            setContent {
+                Toggleable(
+                    checked = false,
+                    onCheckedChange = {},
+                    modifier = Modifier.testTag("toggleable-${generation.intValue}").size(48.dp),
+                    style = focusedContentStyle(),
+                ) { observedContentColor = LocalContentColor.current }
+            }
+
+            assertFocusAndColorSurviveRecomposition(
+                targetTagPrefix = "toggleable",
+                generation = generation,
+                observedContentColor = { observedContentColor },
+            )
+        }
+
+    @Test
+    fun selectableKeepsFocusedContentColorAcrossParentRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            var observedContentColor = Color.Unspecified
+
+            setContent {
+                Selectable(
+                    selected = false,
+                    onClick = {},
+                    modifier = Modifier.testTag("selectable-${generation.intValue}").size(48.dp),
+                    style = focusedContentStyle(),
+                ) { observedContentColor = LocalContentColor.current }
+            }
+
+            assertFocusAndColorSurviveRecomposition(
+                targetTagPrefix = "selectable",
+                generation = generation,
+                observedContentColor = { observedContentColor },
+            )
+        }
+
     @Test
     fun toggleableOwnsStableImplicitInteractionSource() =
         runComposeUiTest {
@@ -102,6 +156,83 @@ class ToggleableInteractionSourceOwnershipTest {
                 assertSame(source, compositionData.directlyOwnedInteractionSources().single())
             }
         }
+
+    @Test
+    fun selectableEmitsFocusIntoExplicitInteractionSource() =
+        runComposeUiTest {
+            val source = RecordingMutableInteractionSource()
+
+            setContent {
+                Selectable(
+                    selected = false,
+                    onClick = {},
+                    modifier = Modifier.testTag("selectable").size(48.dp),
+                    interactionSource = source,
+                ) {}
+            }
+
+            onNodeWithTag("selectable")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+                .assertIsFocused()
+            waitForIdle()
+
+            runOnIdle {
+                assertTrue(
+                    source.emittedInteractions.any {
+                        it is androidx.compose.foundation.interaction.FocusInteraction.Focus
+                    },
+                )
+            }
+        }
+}
+
+private val UnfocusedContentColor = Color.Red
+private val FocusedContentColor = Color.Green
+
+private fun focusedContentStyle() =
+    StyleDefaults.style(
+        colors =
+            StyleDefaults.colors(
+                contentColor = UnfocusedContentColor,
+                focusedContentColor = FocusedContentColor,
+            ),
+    )
+
+@OptIn(ExperimentalTestApi::class)
+private fun androidx.compose.ui.test.ComposeUiTest.assertFocusAndColorSurviveRecomposition(
+    targetTagPrefix: String,
+    generation: androidx.compose.runtime.MutableIntState,
+    observedContentColor: () -> Color,
+) {
+    runOnIdle { assertEquals(UnfocusedContentColor, observedContentColor()) }
+    onNodeWithTag("$targetTagPrefix-0")
+        .performSemanticsAction(SemanticsActions.RequestFocus)
+        .assertIsFocused()
+    waitForIdle()
+    runOnIdle { assertEquals(FocusedContentColor, observedContentColor()) }
+
+    runOnIdle { generation.intValue++ }
+
+    onNodeWithTag("$targetTagPrefix-1").assertIsFocused()
+    runOnIdle { assertEquals(FocusedContentColor, observedContentColor()) }
+}
+
+private class RecordingMutableInteractionSource : MutableInteractionSource {
+    private val delegate = MutableInteractionSource()
+
+    val emittedInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+
+    override val interactions: Flow<androidx.compose.foundation.interaction.Interaction> = delegate.interactions
+
+    override suspend fun emit(interaction: androidx.compose.foundation.interaction.Interaction) {
+        emittedInteractions += interaction
+        delegate.emit(interaction)
+    }
+
+    override fun tryEmit(interaction: androidx.compose.foundation.interaction.Interaction): Boolean {
+        emittedInteractions += interaction
+        return delegate.tryEmit(interaction)
+    }
 }
 
 private fun CompositionData.directlyOwnedInteractionSources(): List<MutableInteractionSource> =

--- a/foundations/build.gradle.kts
+++ b/foundations/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright 2024, Dai Williams
 // SPDX-License-Identifier: Apache-2.0
+@file:OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+
 plugins {
     id("io.daio.compose")
     id("io.daio.android.library")
@@ -19,6 +21,18 @@ kotlin {
             dependencies {
                 implementation(compose.foundation)
                 implementation(projects.modifier)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(compose.uiTest)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
             }
         }
     }

--- a/foundations/build.gradle.kts
+++ b/foundations/build.gradle.kts
@@ -24,14 +24,10 @@ kotlin {
             }
         }
 
-        commonTest {
+        val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(compose.uiTest)
-            }
-        }
-        val jvmTest by getting {
-            dependencies {
                 implementation(compose.desktop.currentOs)
             }
         }

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -8,16 +8,18 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusEventModifierNode
+import androidx.compose.ui.focus.FocusProperties
+import androidx.compose.ui.focus.FocusPropertiesModifierNode
 import androidx.compose.ui.focus.FocusState
-import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.FocusTargetModifierNode
+import androidx.compose.ui.focus.Focusability
+import androidx.compose.ui.focus.invalidateFocusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -25,19 +27,24 @@ import androidx.compose.ui.input.key.KeyInputModifierNode
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.SemanticsModifierNode
 import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateSemantics
+import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.focused
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.requestFocus
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
-import io.daio.wild.modifier.thenIf
-import io.daio.wild.modifier.thenIfNotNull
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -314,82 +321,130 @@ private fun Modifier.handleTvInputIfRequired(
     onDoubleClick: (() -> Unit)? = null,
     onClickLabel: String? = null,
     onClick: (() -> Unit),
-) = this.composed {
-    val hardwareInputDevice = LocalPlatformInteractions.current.requiresHardwareInput
-    // On Tv we disable click actions but maintain focusable to ensure navigation through UI.
-    val focusEnabled = enabled || hardwareInputDevice
+) = this then PlatformFocusableElement(enabled, interactionSource) then
+    HardwareEnterKeyElement(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+        observePlatformInteractions = true,
+        selected = selected,
+        role = role,
+        onLongClickLabel = onLongClickLabel,
+        onClickLabel = onClickLabel,
+    )
 
-    this.focusable(enabled = focusEnabled, interactionSource = interactionSource)
-        .thenIf(
-            condition = hardwareInputDevice,
-            ifTrueModifier =
-                Modifier.handleHardwareInputEnter(
-                    enabled = enabled,
-                    interactionSource = interactionSource,
-                    onClick = onClick,
-                    onLongClick = onLongClick,
-                    onDoubleClick = onDoubleClick,
-                ).hardwareSemantics(
-                    enabled = enabled,
-                    selected = selected,
-                    role = role,
-                    interactionSource = interactionSource,
-                    onLongClickLabel = onLongClickLabel,
-                    onLongClick = onLongClick,
-                    onClickLabel = onClickLabel,
-                    onClick = onClick,
-                ).focusProperties {
-                    // Since we already configure the node to be focusable we want to ensure any
-                    // modifiers applied after that create new focusable Nodes can not be focused.
-                    // This ensures the Composable can not be focused if the component itself has
-                    // canFocus disabled.
-                    canFocus = false
-                },
-        )
+private data class PlatformFocusableElement(
+    val enabled: Boolean,
+    val interactionSource: MutableInteractionSource?,
+) : ModifierNodeElement<PlatformFocusableNode>() {
+    override fun create(): PlatformFocusableNode = PlatformFocusableNode(enabled, interactionSource)
+
+    override fun update(node: PlatformFocusableNode) {
+        node.update(enabled, interactionSource)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "platformFocusable"
+        properties["enabled"] = enabled
+        properties["interactionSource"] = interactionSource
+    }
 }
 
-private fun Modifier.hardwareSemantics(
-    enabled: Boolean,
-    role: Role?,
-    interactionSource: MutableInteractionSource?,
-    indication: Indication? = null,
-    selected: Boolean? = null,
-    onLongClickLabel: String? = null,
-    onLongClick: (() -> Unit)? = null,
-    onClickLabel: String? = null,
-    onClick: (() -> Unit)? = null,
-): Modifier =
-    this.semantics(mergeDescendants = true) {
-        if (selected != null) {
-            this.selected = selected
-        }
+@OptIn(ExperimentalWildApi::class)
+private class PlatformFocusableNode(
+    private var enabled: Boolean,
+    private var interactionSource: MutableInteractionSource?,
+) : DelegatingNode(),
+    CompositionLocalConsumerModifierNode,
+    ObserverModifierNode,
+    SemanticsModifierNode {
+    private val focusTarget =
+        delegate(
+            FocusTargetModifierNode(
+                focusability = Focusability.Never,
+                onFocusChange = ::onFocusChange,
+            ),
+        )
+    private var focusInteraction: FocusInteraction.Focus? = null
+    private var focusEnabled = false
 
-        if (role != null) {
-            this.role = role
+    override fun onAttach() {
+        updateFocusability()
+    }
+
+    override fun onObservedReadsChanged() {
+        updateFocusability()
+    }
+
+    fun update(
+        enabled: Boolean,
+        interactionSource: MutableInteractionSource?,
+    ) {
+        if (this.interactionSource !== interactionSource) {
+            disposeFocusInteraction()
+            this.interactionSource = interactionSource
+            if (focusTarget.focusState.isFocused) emitFocusInteraction()
         }
-        onClick(label = onClickLabel) {
-            onClick?.let { nnOnClick ->
-                nnOnClick()
-                return@onClick true
+        if (this.enabled != enabled) {
+            this.enabled = enabled
+            if (isAttached) updateFocusability()
+        }
+    }
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        if (focusEnabled) {
+            focused = focusTarget.focusState.isFocused
+            requestFocus { focusTarget.requestFocus() }
+        }
+    }
+
+    override fun onDetach() {
+        disposeFocusInteraction()
+    }
+
+    private fun updateFocusability() {
+        var requiresHardwareInput = false
+        observeReads {
+            requiresHardwareInput = currentValueOf(LocalPlatformInteractions).requiresHardwareInput
+        }
+        focusEnabled = enabled || requiresHardwareInput
+        focusTarget.focusability =
+            if (focusEnabled) {
+                Focusability.Always
+            } else {
+                Focusability.Never
             }
-            false
+        invalidateSemantics()
+    }
+
+    private fun onFocusChange(
+        previous: FocusState,
+        current: FocusState,
+    ) {
+        if (previous.isFocused == current.isFocused) return
+        if (current.isFocused) {
+            emitFocusInteraction()
+        } else {
+            disposeFocusInteraction()
         }
-        onLongClick(label = onLongClickLabel) {
-            onLongClick?.let { nnOnLongClick ->
-                nnOnLongClick()
-                return@onLongClick true
-            }
-            false
+        invalidateSemantics()
+    }
+
+    private fun emitFocusInteraction() {
+        val interaction = FocusInteraction.Focus()
+        focusInteraction = interaction
+        coroutineScope.launch { interactionSource?.emit(interaction) }
+    }
+
+    private fun disposeFocusInteraction() {
+        focusInteraction?.let { interaction ->
+            interactionSource?.tryEmit(FocusInteraction.Unfocus(interaction))
         }
-        if (!enabled) {
-            disabled()
-        }
-    }.thenIfNotNull(
-        value = interactionSource,
-        ifNotNullModifier = { interactionSource ->
-            Modifier.indication(interactionSource, indication)
-        },
-    )
+        focusInteraction = null
+    }
+}
 
 /**
  * Modifier to set up handling of hardware input enter keys, such as Tv remote Dpad enter and
@@ -404,11 +459,11 @@ internal fun Modifier.handleHardwareInputEnter(
 ): Modifier =
     this then
         HardwareEnterKeyElement(
-            enabled,
-            interactionSource,
-            onClick,
-            onLongClick,
-            onDoubleClick,
+            enabled = enabled,
+            interactionSource = interactionSource,
+            onClick = onClick,
+            onLongClick = onLongClick,
+            onDoubleClick = onDoubleClick,
         )
 
 private data class HardwareEnterKeyElement(
@@ -417,6 +472,11 @@ private data class HardwareEnterKeyElement(
     val onClick: (() -> Unit)? = null,
     val onLongClick: (() -> Unit)? = null,
     val onDoubleClick: (() -> Unit)? = null,
+    val observePlatformInteractions: Boolean = false,
+    val selected: Boolean? = null,
+    val role: Role? = null,
+    val onLongClickLabel: String? = null,
+    val onClickLabel: String? = null,
 ) : ModifierNodeElement<HardwareEnterKeyEventNode>() {
     override fun create(): HardwareEnterKeyEventNode =
         HardwareEnterKeyEventNode(
@@ -425,6 +485,11 @@ private data class HardwareEnterKeyElement(
             onClick = onClick,
             onLongClick = onLongClick,
             onDoubleClick = onDoubleClick,
+            observePlatformInteractions = observePlatformInteractions,
+            selected = selected,
+            role = role,
+            onLongClickLabel = onLongClickLabel,
+            onClickLabel = onClickLabel,
         )
 
     override fun update(node: HardwareEnterKeyEventNode) {
@@ -433,6 +498,12 @@ private data class HardwareEnterKeyElement(
         node.onClick = onClick
         node.onLongClick = onLongClick
         node.onDoubleClick = onDoubleClick
+        node.observePlatformInteractions = observePlatformInteractions
+        node.selected = selected
+        node.role = role
+        node.onLongClickLabel = onLongClickLabel
+        node.onClickLabel = onClickLabel
+        if (node.isAttached) node.updatePlatformConfiguration()
     }
 
     override fun InspectorInfo.inspectableProperties() {
@@ -442,6 +513,11 @@ private data class HardwareEnterKeyElement(
         properties["onClick"] = onClick
         properties["onLongClick"] = onLongClick
         properties["onDoubleClick"] = onDoubleClick
+        properties["observePlatformInteractions"] = observePlatformInteractions
+        properties["selected"] = selected
+        properties["role"] = role
+        properties["onLongClickLabel"] = onLongClickLabel
+        properties["onClickLabel"] = onClickLabel
     }
 }
 
@@ -451,10 +527,18 @@ private class HardwareEnterKeyEventNode(
     var onLongClick: (() -> Unit)? = null,
     var onDoubleClick: (() -> Unit)? = null,
     var interactionSource: MutableInteractionSource?,
+    var observePlatformInteractions: Boolean = false,
+    var selected: Boolean? = null,
+    var role: Role? = null,
+    var onLongClickLabel: String? = null,
+    var onClickLabel: String? = null,
     var timeNow: () -> Instant = { Clock.System.now() },
 ) : KeyInputModifierNode,
     FocusEventModifierNode,
     CompositionLocalConsumerModifierNode,
+    ObserverModifierNode,
+    SemanticsModifierNode,
+    FocusPropertiesModifierNode,
     Modifier.Node() {
     private val pressInteraction = PressInteraction.Press(Offset.Zero)
     private var focusState: FocusState? = null
@@ -466,14 +550,58 @@ private class HardwareEnterKeyEventNode(
     private var awaitingSecondClick: Boolean = false
     private var doubleClickTimeoutJob: Job? = null
     private var doubleClickTimeout: Duration = 300.milliseconds
+    private var hardwareInputRequired: Boolean = !observePlatformInteractions
 
     override fun onAttach() {
-        doubleClickTimeout =
-            currentValueOf(LocalViewConfiguration).doubleTapTimeoutMillis.milliseconds
+        updatePlatformConfiguration()
+    }
+
+    override fun onObservedReadsChanged() {
+        updatePlatformConfiguration()
+    }
+
+    @OptIn(ExperimentalWildApi::class)
+    fun updatePlatformConfiguration() {
+        val previouslyRequiredHardwareInput = hardwareInputRequired
+        observeReads {
+            doubleClickTimeout =
+                currentValueOf(LocalViewConfiguration).doubleTapTimeoutMillis.milliseconds
+            hardwareInputRequired =
+                !observePlatformInteractions ||
+                currentValueOf(LocalPlatformInteractions).requiresHardwareInput
+        }
+        if (previouslyRequiredHardwareInput && !hardwareInputRequired && pressed) {
+            resetDoubleClick()
+            releasePressInteraction()
+        }
+        invalidateSemantics()
+        invalidateFocusProperties()
+    }
+
+    override fun applyFocusProperties(focusProperties: FocusProperties) {
+        if (hardwareInputRequired) {
+            focusProperties.canFocus = false
+        }
+    }
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        if (!observePlatformInteractions || !hardwareInputRequired) return
+
+        this@HardwareEnterKeyEventNode.selected?.let { selected = it }
+        this@HardwareEnterKeyEventNode.role?.let { role = it }
+        onClick(label = onClickLabel) {
+            this@HardwareEnterKeyEventNode.onClick?.invoke()
+            this@HardwareEnterKeyEventNode.onClick != null
+        }
+        onLongClick(label = onLongClickLabel) {
+            this@HardwareEnterKeyEventNode.onLongClick?.invoke()
+            this@HardwareEnterKeyEventNode.onLongClick != null
+        }
+        if (!enabled) disabled()
     }
 
     override fun onKeyEvent(event: KeyEvent): Boolean {
-        if (HardwareEnterKeys.contains(event.key.keyCode) && enabled) {
+        if (hardwareInputRequired && HardwareEnterKeys.contains(event.key.keyCode) && enabled) {
             when (event.type) {
                 KeyEventType.KeyDown -> {
                     when (event.repeatCount) {

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -422,6 +422,7 @@ internal fun Modifier.handleHardwareInputEnter(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
+    eventRepeatCount: ((KeyEvent) -> Int)? = null,
 ): Modifier =
     this then
         HardwareEnterKeyElement(
@@ -430,6 +431,7 @@ internal fun Modifier.handleHardwareInputEnter(
             onClick = onClick,
             onLongClick = onLongClick,
             onDoubleClick = onDoubleClick,
+            eventRepeatCount = eventRepeatCount,
         )
 
 private data class HardwareEnterKeyElement(
@@ -443,6 +445,7 @@ private data class HardwareEnterKeyElement(
     val role: Role? = null,
     val onLongClickLabel: String? = null,
     val onClickLabel: String? = null,
+    val eventRepeatCount: ((KeyEvent) -> Int)? = null,
 ) : ModifierNodeElement<HardwareEnterKeyEventNode>() {
     override fun create(): HardwareEnterKeyEventNode =
         HardwareEnterKeyEventNode(
@@ -456,6 +459,7 @@ private data class HardwareEnterKeyElement(
             role = role,
             onLongClickLabel = onLongClickLabel,
             onClickLabel = onClickLabel,
+            eventRepeatCount = eventRepeatCount,
         )
 
     override fun update(node: HardwareEnterKeyEventNode) {
@@ -470,6 +474,7 @@ private data class HardwareEnterKeyElement(
             role = role,
             onLongClickLabel = onLongClickLabel,
             onClickLabel = onClickLabel,
+            eventRepeatCount = eventRepeatCount,
         )
     }
 
@@ -485,6 +490,7 @@ private data class HardwareEnterKeyElement(
         properties["role"] = role
         properties["onLongClickLabel"] = onLongClickLabel
         properties["onClickLabel"] = onClickLabel
+        properties["eventRepeatCount"] = eventRepeatCount
     }
 }
 
@@ -499,6 +505,7 @@ private class HardwareEnterKeyEventNode(
     private var role: Role? = null,
     private var onLongClickLabel: String? = null,
     private var onClickLabel: String? = null,
+    private var eventRepeatCount: ((KeyEvent) -> Int)? = null,
     var timeNow: () -> Instant = { Clock.System.now() },
 ) : KeyInputModifierNode,
     FocusEventModifierNode,
@@ -534,10 +541,10 @@ private class HardwareEnterKeyEventNode(
         role: Role?,
         onLongClickLabel: String?,
         onClickLabel: String?,
+        eventRepeatCount: ((KeyEvent) -> Int)?,
     ) {
-        if (activePress != null && (!enabled || interactionSource !== this.interactionSource)) {
-            resetDoubleClick()
-            cancelPressInteraction()
+        if (!enabled || (activePress != null && interactionSource !== this.interactionSource)) {
+            terminateGesture()
         }
 
         this.enabled = enabled
@@ -550,6 +557,7 @@ private class HardwareEnterKeyEventNode(
         this.role = role
         this.onLongClickLabel = onLongClickLabel
         this.onClickLabel = onClickLabel
+        this.eventRepeatCount = eventRepeatCount
         if (isAttached) updatePlatformConfiguration()
     }
 
@@ -605,7 +613,7 @@ private class HardwareEnterKeyEventNode(
         if (hardwareInputRequired && HardwareEnterKeys.contains(event.key.keyCode) && enabled) {
             when (event.type) {
                 KeyEventType.KeyDown -> {
-                    when (event.repeatCount) {
+                    when (eventRepeatCount?.invoke(event) ?: event.repeatCount) {
                         0 -> {
                             // If we are handling double clicks we should check if this
                             // key down event is potentially a second click.
@@ -636,8 +644,7 @@ private class HardwareEnterKeyEventNode(
                             onClick?.invoke()
                         }
                     } else {
-                        activePress = null
-                        isLongClick = false
+                        terminateGesture()
                     }
                 }
             }
@@ -661,11 +668,11 @@ private class HardwareEnterKeyEventNode(
     }
 
     override fun onReset() {
-        reset()
+        terminateGesture(synchronously = true)
     }
 
     override fun onDetach() {
-        reset()
+        terminateGesture(synchronously = true)
     }
 
     private fun emitPressInteraction() {
@@ -686,12 +693,16 @@ private class HardwareEnterKeyEventNode(
         }
     }
 
-    private fun cancelPressInteraction() {
+    private fun cancelPressInteraction(synchronously: Boolean) {
         val press = activePress ?: return
         activePress = null
-        isLongClick = false
-        coroutineScope.launch {
-            press.interactionSource?.emit(PressInteraction.Cancel(press.interaction))
+        val cancel = PressInteraction.Cancel(press.interaction)
+        if (synchronously) {
+            press.interactionSource?.tryEmit(cancel)
+        } else {
+            coroutineScope.launch {
+                press.interactionSource?.emit(cancel)
+            }
         }
     }
 
@@ -742,9 +753,9 @@ private class HardwareEnterKeyEventNode(
         }
     }
 
-    private fun reset() {
+    private fun terminateGesture(synchronously: Boolean = false) {
         resetDoubleClick()
-        activePress = null
+        cancelPressInteraction(synchronously)
         isLongClick = false
     }
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -459,17 +459,18 @@ private data class HardwareEnterKeyElement(
         )
 
     override fun update(node: HardwareEnterKeyEventNode) {
-        node.enabled = enabled
-        node.interactionSource = interactionSource
-        node.onClick = onClick
-        node.onLongClick = onLongClick
-        node.onDoubleClick = onDoubleClick
-        node.observePlatformInteractions = observePlatformInteractions
-        node.selected = selected
-        node.role = role
-        node.onLongClickLabel = onLongClickLabel
-        node.onClickLabel = onClickLabel
-        if (node.isAttached) node.updatePlatformConfiguration()
+        node.update(
+            enabled = enabled,
+            interactionSource = interactionSource,
+            onClick = onClick,
+            onLongClick = onLongClick,
+            onDoubleClick = onDoubleClick,
+            observePlatformInteractions = observePlatformInteractions,
+            selected = selected,
+            role = role,
+            onLongClickLabel = onLongClickLabel,
+            onClickLabel = onClickLabel,
+        )
     }
 
     override fun InspectorInfo.inspectableProperties() {
@@ -488,16 +489,16 @@ private data class HardwareEnterKeyElement(
 }
 
 private class HardwareEnterKeyEventNode(
-    var enabled: Boolean,
-    var onClick: (() -> Unit)? = null,
-    var onLongClick: (() -> Unit)? = null,
-    var onDoubleClick: (() -> Unit)? = null,
-    var interactionSource: MutableInteractionSource?,
-    var observePlatformInteractions: Boolean = false,
-    var selected: Boolean? = null,
-    var role: Role? = null,
-    var onLongClickLabel: String? = null,
-    var onClickLabel: String? = null,
+    private var enabled: Boolean,
+    private var onClick: (() -> Unit)? = null,
+    private var onLongClick: (() -> Unit)? = null,
+    private var onDoubleClick: (() -> Unit)? = null,
+    private var interactionSource: MutableInteractionSource?,
+    private var observePlatformInteractions: Boolean = false,
+    private var selected: Boolean? = null,
+    private var role: Role? = null,
+    private var onLongClickLabel: String? = null,
+    private var onClickLabel: String? = null,
     var timeNow: () -> Instant = { Clock.System.now() },
 ) : KeyInputModifierNode,
     FocusEventModifierNode,
@@ -506,9 +507,13 @@ private class HardwareEnterKeyEventNode(
     SemanticsModifierNode,
     FocusPropertiesModifierNode,
     Modifier.Node() {
-    private val pressInteraction = PressInteraction.Press(Offset.Zero)
+    private data class ActivePress(
+        val interaction: PressInteraction.Press,
+        val interactionSource: MutableInteractionSource?,
+    )
+
     private var focusState: FocusState? = null
-    private var pressed: Boolean = false
+    private var activePress: ActivePress? = null
     private var isLongClick: Boolean = false
 
     // Double-click state
@@ -517,6 +522,36 @@ private class HardwareEnterKeyEventNode(
     private var doubleClickTimeoutJob: Job? = null
     private var doubleClickTimeout: Duration = 300.milliseconds
     private var hardwareInputRequired: Boolean = !observePlatformInteractions
+
+    fun update(
+        enabled: Boolean,
+        interactionSource: MutableInteractionSource?,
+        onClick: (() -> Unit)?,
+        onLongClick: (() -> Unit)?,
+        onDoubleClick: (() -> Unit)?,
+        observePlatformInteractions: Boolean,
+        selected: Boolean?,
+        role: Role?,
+        onLongClickLabel: String?,
+        onClickLabel: String?,
+    ) {
+        if (activePress != null && (!enabled || interactionSource !== this.interactionSource)) {
+            resetDoubleClick()
+            cancelPressInteraction()
+        }
+
+        this.enabled = enabled
+        this.interactionSource = interactionSource
+        this.onClick = onClick
+        this.onLongClick = onLongClick
+        this.onDoubleClick = onDoubleClick
+        this.observePlatformInteractions = observePlatformInteractions
+        this.selected = selected
+        this.role = role
+        this.onLongClickLabel = onLongClickLabel
+        this.onClickLabel = onClickLabel
+        if (isAttached) updatePlatformConfiguration()
+    }
 
     override fun onAttach() {
         updatePlatformConfiguration()
@@ -536,7 +571,7 @@ private class HardwareEnterKeyEventNode(
                 !observePlatformInteractions ||
                 currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
-        if (previouslyRequiredHardwareInput && !hardwareInputRequired && pressed) {
+        if (previouslyRequiredHardwareInput && !hardwareInputRequired && activePress != null) {
             resetDoubleClick()
             releasePressInteraction()
         }
@@ -593,7 +628,7 @@ private class HardwareEnterKeyEventNode(
                 }
 
                 KeyEventType.KeyUp -> {
-                    if (!isLongClick && pressed) {
+                    if (!isLongClick && activePress != null) {
                         releasePressInteraction()
                         if (onDoubleClick != null) {
                             handleAsDoubleClick()
@@ -601,7 +636,7 @@ private class HardwareEnterKeyEventNode(
                             onClick?.invoke()
                         }
                     } else {
-                        pressed = false
+                        activePress = null
                         isLongClick = false
                     }
                 }
@@ -618,7 +653,7 @@ private class HardwareEnterKeyEventNode(
         if (this.focusState != focusState) {
             this.focusState = focusState
 
-            if (!focusState.isFocused && pressed) {
+            if (!focusState.isFocused && activePress != null) {
                 resetDoubleClick()
                 releasePressInteraction()
             }
@@ -634,16 +669,29 @@ private class HardwareEnterKeyEventNode(
     }
 
     private fun emitPressInteraction() {
+        if (activePress != null) return
+
+        val press = ActivePress(PressInteraction.Press(Offset.Zero), interactionSource)
+        activePress = press
         coroutineScope.launch {
-            interactionSource?.emit(pressInteraction)
-            pressed = true
+            press.interactionSource?.emit(press.interaction)
         }
     }
 
     private fun releasePressInteraction() {
+        val press = activePress ?: return
+        activePress = null
         coroutineScope.launch {
-            interactionSource?.emit(PressInteraction.Release(pressInteraction))
-            pressed = false
+            press.interactionSource?.emit(PressInteraction.Release(press.interaction))
+        }
+    }
+
+    private fun cancelPressInteraction() {
+        val press = activePress ?: return
+        activePress = null
+        isLongClick = false
+        coroutineScope.launch {
+            press.interactionSource?.emit(PressInteraction.Cancel(press.interaction))
         }
     }
 
@@ -696,7 +744,7 @@ private class HardwareEnterKeyEventNode(
 
     private fun reset() {
         resetDoubleClick()
-        pressed = false
+        activePress = null
         isLongClick = false
     }
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.selection.selectable
@@ -17,8 +17,6 @@ import androidx.compose.ui.focus.FocusEventModifierNode
 import androidx.compose.ui.focus.FocusProperties
 import androidx.compose.ui.focus.FocusPropertiesModifierNode
 import androidx.compose.ui.focus.FocusState
-import androidx.compose.ui.focus.FocusTargetModifierNode
-import androidx.compose.ui.focus.Focusability
 import androidx.compose.ui.focus.invalidateFocusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
@@ -27,7 +25,6 @@ import androidx.compose.ui.input.key.KeyInputModifierNode
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
-import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.SemanticsModifierNode
@@ -39,10 +36,8 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.disabled
-import androidx.compose.ui.semantics.focused
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.onLongClick
-import androidx.compose.ui.semantics.requestFocus
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import kotlinx.coroutines.Job
@@ -321,7 +316,8 @@ private fun Modifier.handleTvInputIfRequired(
     onDoubleClick: (() -> Unit)? = null,
     onClickLabel: String? = null,
     onClick: (() -> Unit),
-) = this then PlatformFocusableElement(enabled, interactionSource) then
+) = this then PlatformFocusabilityElement(enabled) then
+    Modifier.focusable(enabled = true, interactionSource = interactionSource) then
     HardwareEnterKeyElement(
         enabled = enabled,
         interactionSource = interactionSource,
@@ -335,114 +331,56 @@ private fun Modifier.handleTvInputIfRequired(
         onClickLabel = onClickLabel,
     )
 
-private data class PlatformFocusableElement(
+private data class PlatformFocusabilityElement(
     val enabled: Boolean,
-    val interactionSource: MutableInteractionSource?,
-) : ModifierNodeElement<PlatformFocusableNode>() {
-    override fun create(): PlatformFocusableNode = PlatformFocusableNode(enabled, interactionSource)
+) : ModifierNodeElement<PlatformFocusabilityNode>() {
+    override fun create(): PlatformFocusabilityNode = PlatformFocusabilityNode(enabled)
 
-    override fun update(node: PlatformFocusableNode) {
-        node.update(enabled, interactionSource)
+    override fun update(node: PlatformFocusabilityNode) {
+        node.update(enabled)
     }
 
     override fun InspectorInfo.inspectableProperties() {
-        name = "platformFocusable"
+        name = "platformFocusability"
         properties["enabled"] = enabled
-        properties["interactionSource"] = interactionSource
     }
 }
 
 @OptIn(ExperimentalWildApi::class)
-private class PlatformFocusableNode(
+private class PlatformFocusabilityNode(
     private var enabled: Boolean,
-    private var interactionSource: MutableInteractionSource?,
-) : DelegatingNode(),
+) : Modifier.Node(),
     CompositionLocalConsumerModifierNode,
     ObserverModifierNode,
-    SemanticsModifierNode {
-    private val focusTarget =
-        delegate(
-            FocusTargetModifierNode(
-                focusability = Focusability.Never,
-                onFocusChange = ::onFocusChange,
-            ),
-        )
-    private var focusInteraction: FocusInteraction.Focus? = null
+    FocusPropertiesModifierNode {
     private var focusEnabled = false
 
     override fun onAttach() {
-        updateFocusability()
+        updateFocusProperties()
     }
 
     override fun onObservedReadsChanged() {
-        updateFocusability()
+        updateFocusProperties()
     }
 
-    fun update(
-        enabled: Boolean,
-        interactionSource: MutableInteractionSource?,
-    ) {
-        if (this.interactionSource !== interactionSource) {
-            disposeFocusInteraction()
-            this.interactionSource = interactionSource
-            if (focusTarget.focusState.isFocused) emitFocusInteraction()
-        }
+    fun update(enabled: Boolean) {
         if (this.enabled != enabled) {
             this.enabled = enabled
-            if (isAttached) updateFocusability()
+            if (isAttached) updateFocusProperties()
         }
     }
 
-    override fun SemanticsPropertyReceiver.applySemantics() {
-        if (focusEnabled) {
-            focused = focusTarget.focusState.isFocused
-            requestFocus { focusTarget.requestFocus() }
-        }
+    override fun applyFocusProperties(focusProperties: FocusProperties) {
+        focusProperties.canFocus = focusEnabled
     }
 
-    override fun onDetach() {
-        disposeFocusInteraction()
-    }
-
-    private fun updateFocusability() {
+    private fun updateFocusProperties() {
         var requiresHardwareInput = false
         observeReads {
             requiresHardwareInput = currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
         focusEnabled = enabled || requiresHardwareInput
-        focusTarget.focusability =
-            if (focusEnabled) {
-                Focusability.Always
-            } else {
-                Focusability.Never
-            }
-        invalidateSemantics()
-    }
-
-    private fun onFocusChange(
-        previous: FocusState,
-        current: FocusState,
-    ) {
-        if (previous.isFocused == current.isFocused) return
-        if (current.isFocused) {
-            emitFocusInteraction()
-        } else {
-            disposeFocusInteraction()
-        }
-        invalidateSemantics()
-    }
-
-    private fun emitFocusInteraction() {
-        val interaction = FocusInteraction.Focus()
-        focusInteraction = interaction
-        coroutineScope.launch { interactionSource?.emit(interaction) }
-    }
-
-    private fun disposeFocusInteraction() {
-        focusInteraction?.let { interaction ->
-            interactionSource?.tryEmit(FocusInteraction.Unfocus(interaction))
-        }
-        focusInteraction = null
+        invalidateFocusProperties()
     }
 }
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.input.key.KeyInputModifierNode
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.SemanticsModifierNode
@@ -316,8 +317,7 @@ private fun Modifier.handleTvInputIfRequired(
     onDoubleClick: (() -> Unit)? = null,
     onClickLabel: String? = null,
     onClick: (() -> Unit),
-) = this then PlatformFocusabilityElement(enabled) then
-    Modifier.focusable(enabled = true, interactionSource = interactionSource) then
+) = this then PlatformFocusableElement(enabled, interactionSource) then
     HardwareEnterKeyElement(
         enabled = enabled,
         interactionSource = interactionSource,
@@ -331,57 +331,85 @@ private fun Modifier.handleTvInputIfRequired(
         onClickLabel = onClickLabel,
     )
 
-private data class PlatformFocusabilityElement(
+private data class PlatformFocusableElement(
     val enabled: Boolean,
-) : ModifierNodeElement<PlatformFocusabilityNode>() {
-    override fun create(): PlatformFocusabilityNode = PlatformFocusabilityNode(enabled)
+    val interactionSource: MutableInteractionSource?,
+) : ModifierNodeElement<PlatformFocusableNode>() {
+    override fun create(): PlatformFocusableNode = PlatformFocusableNode(enabled, interactionSource)
 
-    override fun update(node: PlatformFocusabilityNode) {
-        node.update(enabled)
+    override fun update(node: PlatformFocusableNode) {
+        node.update(enabled, interactionSource)
     }
 
     override fun InspectorInfo.inspectableProperties() {
-        name = "platformFocusability"
+        name = "platformFocusable"
         properties["enabled"] = enabled
+        properties["interactionSource"] = interactionSource
     }
 }
 
 @OptIn(ExperimentalWildApi::class)
-private class PlatformFocusabilityNode(
+private class PlatformFocusableNode(
     private var enabled: Boolean,
-) : Modifier.Node(),
+    private var interactionSource: MutableInteractionSource?,
+) : DelegatingNode(),
     CompositionLocalConsumerModifierNode,
-    ObserverModifierNode,
-    FocusPropertiesModifierNode {
-    private var focusEnabled = false
+    ObserverModifierNode {
+    private var focusableElement = focusableNodeElement(interactionSource)
+    private val focusableNode = focusableElement.create()
+    private var focusableNodeDelegated = false
 
     override fun onAttach() {
-        updateFocusProperties()
+        updateFocusableDelegation()
     }
 
     override fun onObservedReadsChanged() {
-        updateFocusProperties()
+        updateFocusableDelegation()
     }
 
-    fun update(enabled: Boolean) {
+    fun update(
+        enabled: Boolean,
+        interactionSource: MutableInteractionSource?,
+    ) {
+        if (this.interactionSource !== interactionSource) {
+            this.interactionSource = interactionSource
+            focusableElement = focusableNodeElement(interactionSource)
+            focusableElement.update(focusableNode)
+        }
         if (this.enabled != enabled) {
             this.enabled = enabled
-            if (isAttached) updateFocusProperties()
+            if (isAttached) updateFocusableDelegation()
         }
     }
 
-    override fun applyFocusProperties(focusProperties: FocusProperties) {
-        focusProperties.canFocus = focusEnabled
-    }
-
-    private fun updateFocusProperties() {
+    private fun updateFocusableDelegation() {
         var requiresHardwareInput = false
         observeReads {
             requiresHardwareInput = currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
-        focusEnabled = enabled || requiresHardwareInput
-        invalidateFocusProperties()
+        val shouldDelegate = enabled || requiresHardwareInput
+        if (shouldDelegate && !focusableNodeDelegated) {
+            delegate(focusableNode)
+            focusableNodeDelegated = true
+        } else if (!shouldDelegate && focusableNodeDelegated) {
+            undelegate(focusableNode)
+            focusableNodeDelegated = false
+        }
     }
+}
+
+// Compose 1.11.1 exposes focusable as one ordinary node element. Retain that complete node so its
+// pinning, focused-bounds, semantics, and interaction lifecycle can be conditionally delegated.
+@Suppress("UNCHECKED_CAST")
+private fun focusableNodeElement(interactionSource: MutableInteractionSource?): ModifierNodeElement<Modifier.Node> {
+    val element =
+        Modifier.focusable(enabled = true, interactionSource = interactionSource)
+            .foldIn<Modifier.Element?>(null) { previous, current ->
+                check(previous == null) { "Expected Modifier.focusable to contain one element" }
+                current
+            }
+    check(element is ModifierNodeElement<*>) { "Expected Modifier.focusable to use a modifier node" }
+    return element as ModifierNodeElement<Modifier.Node>
 }
 
 /**

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.foundation
 
+import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -97,6 +101,91 @@ class ClickableFastPathTest {
 
             onNodeWithTag(TARGET_TAG).assertIsFocused().performClick()
             runOnIdle { assertEquals(1, clicks) }
+        }
+
+    @Test
+    fun focusedLazyItemRemainsPinnedWhenScrolledOutOfView() =
+        runComposeUiTest {
+            var scrollToItem by mutableStateOf(0)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    val state = rememberLazyListState()
+                    LazyColumn(
+                        modifier = Modifier.size(width = 100.dp, height = 30.dp),
+                        state = state,
+                    ) {
+                        items(30) { index ->
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(width = 100.dp, height = 10.dp)
+                                        .clickable(
+                                            interactionSource = MutableInteractionSource(),
+                                            onClick = {},
+                                        ).testTag("item-$index"),
+                            )
+                        }
+                    }
+                    LaunchedEffect(scrollToItem) {
+                        if (scrollToItem > 0) state.scrollToItem(scrollToItem)
+                    }
+                }
+            }
+
+            onNodeWithTag("item-0")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+                .assertIsFocused()
+            runOnIdle { scrollToItem = 20 }
+            waitForIdle()
+
+            onNodeWithTag("item-0").assertIsFocused()
+        }
+
+    @Test
+    fun replacingSourceWhileFocusedBalancesOnlyTheOldSource() =
+        runComposeUiTest {
+            val firstSource = MutableInteractionSource()
+            val secondSource = MutableInteractionSource()
+            val firstInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val secondInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var source by mutableStateOf(firstSource)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(interactionSource = source, onClick = {})
+                                .testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(firstSource) {
+                        firstSource.interactions.collect { firstInteractions += it }
+                    }
+                    LaunchedEffect(secondSource) {
+                        secondSource.interactions.collect { secondInteractions += it }
+                    }
+                }
+            }
+
+            waitUntil { firstInteractions.any { it is FocusInteraction.Focus } }
+            runOnIdle { source = secondSource }
+            waitForIdle()
+
+            runOnIdle {
+                val focus = firstInteractions.filterIsInstance<FocusInteraction.Focus>().single()
+                val unfocus = firstInteractions.filterIsInstance<FocusInteraction.Unfocus>().single()
+                assertSame(focus, unfocus.focus)
+                assertTrue(secondInteractions.none { it is FocusInteraction })
+            }
         }
 
     @Test

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -1,0 +1,286 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.foundation
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class, ExperimentalWildApi::class)
+class ClickableFastPathTest {
+    @Test
+    fun nonNullInteractionSourcesUseOrdinaryModifierChains() {
+        val source = MutableInteractionSource()
+
+        val modifiers =
+            listOf(
+                Modifier.clickable(interactionSource = source, onClick = {}),
+                Modifier.selectable(selected = true, interactionSource = source, onClick = {}),
+                Modifier.interactable(interactionSource = source, onClick = {}),
+                Modifier.interactable(selected = true, interactionSource = source, onClick = {}),
+                Modifier.clickable(interactionSource = null, onClick = {}),
+            )
+
+        modifiers.forEach { modifier ->
+            assertFalse(modifier.hasComposedElement(), "Unexpected composed element in $modifier")
+        }
+    }
+
+    @Test
+    fun receiverStaysFirstInTheFastPathChain() {
+        val source = MutableInteractionSource()
+        val modifier =
+            (Modifier then ReceiverMarker).clickable(
+                interactionSource = source,
+                onClick = {},
+            )
+
+        val elements = modifier.elements()
+
+        assertTrue(elements.size > 1)
+        assertSame(ReceiverMarker, elements.first())
+    }
+
+    @Test
+    fun nonHardwareClickableRemainsFocusableAndClickable() =
+        runComposeUiTest {
+            var clicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = false),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            onNodeWithTag(TARGET_TAG).assertIsFocused().performClick()
+            runOnIdle { assertEquals(1, clicks) }
+        }
+
+    @Test
+    fun hardwareEnterAndLongClickSemanticsInvokeCallbacks() =
+        runComposeUiTest {
+            var clicks = 0
+            var longClicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onLongClick = { longClicks++ },
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitForIdle()
+            target.performKeyInput { keyUp(Key.Enter) }
+            runOnIdle { assertEquals(1, clicks) }
+
+            target.performSemanticsAction(SemanticsActions.OnLongClick)
+            runOnIdle { assertEquals(1, longClicks) }
+        }
+
+    @Test
+    fun hardwareDoubleEnterInvokesDoubleClick() =
+        runComposeUiTest {
+            var clicks = 0
+            var doubleClicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onDoubleClick = { doubleClicks++ },
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            repeat(2) {
+                target.performKeyInput { keyDown(Key.Enter) }
+                waitForIdle()
+                target.performKeyInput { keyUp(Key.Enter) }
+                waitForIdle()
+            }
+
+            runOnIdle {
+                assertEquals(0, clicks)
+                assertEquals(1, doubleClicks)
+            }
+        }
+
+    @Test
+    fun disabledHardwareSelectableRemainsFocusedSelectedAndDoesNotHandleEnter() =
+        runComposeUiTest {
+            var clicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .selectable(
+                                    selected = true,
+                                    enabled = false,
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.assertIsFocused().assertIsSelected().assertIsNotEnabled()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitForIdle()
+            target.performKeyInput { keyUp(Key.Enter) }
+            runOnIdle { assertEquals(0, clicks) }
+        }
+
+    @Test
+    fun hardwareSemanticsMergeDescendants() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = {},
+                                ).testTag(TARGET_TAG),
+                    ) {
+                        Box(modifier = Modifier.semantics { contentDescription = "Child" })
+                    }
+                }
+            }
+
+            onNodeWithTag(TARGET_TAG).assertContentDescriptionEquals("Child")
+        }
+
+    @Test
+    fun leavingHardwareModeReleasesAnActivePress() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var hardwareInput by mutableStateOf(true)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides
+                        PlatformInteractions(requiresHardwareInput = hardwareInput),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(interactionSource = source, onClick = {})
+                                .testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(source) {
+                        source.interactions.collect { interactions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitForIdle()
+            runOnIdle { hardwareInput = false }
+            waitForIdle()
+
+            runOnIdle {
+                assertTrue(interactions.filterIsInstance<PressInteraction>().last() is PressInteraction.Release)
+            }
+        }
+}
+
+private const val TARGET_TAG = "target"
+
+private data object ReceiverMarker : Modifier.Element
+
+private fun Modifier.hasComposedElement(): Boolean =
+    elements().any { element -> element::class.simpleName?.contains("ComposedModifier") == true }
+
+private fun Modifier.elements(): List<Modifier.Element> =
+    buildList {
+        foldIn(Unit) { _, element -> add(element) }
+    }

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -253,6 +253,113 @@ class ClickableFastPathTest {
         }
 
     @Test
+    fun replacingSourceDuringHardwarePressCancelsTheOldSourceWithoutClicking() =
+        runComposeUiTest {
+            val firstSource = MutableInteractionSource()
+            val secondSource = MutableInteractionSource()
+            val firstInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val secondInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var source by mutableStateOf(firstSource)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = source,
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(firstSource) {
+                        firstSource.interactions.collect { firstInteractions += it }
+                    }
+                    LaunchedEffect(secondSource) {
+                        secondSource.interactions.collect { secondInteractions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitUntil { firstInteractions.any { it is PressInteraction.Press } }
+
+            runOnIdle { source = secondSource }
+            waitForIdle()
+
+            runOnIdle {
+                val press = firstInteractions.filterIsInstance<PressInteraction.Press>().single()
+                val cancel = firstInteractions.filterIsInstance<PressInteraction.Cancel>().single()
+                assertSame(press, cancel.press)
+            }
+
+            target.performKeyInput { keyUp(Key.Enter) }
+            waitForIdle()
+
+            runOnIdle {
+                assertEquals(0, clicks)
+                assertTrue(secondInteractions.none { it is PressInteraction })
+            }
+        }
+
+    @Test
+    fun disablingDuringHardwarePressCancelsThePressWithoutClicking() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var enabled by mutableStateOf(true)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    enabled = enabled,
+                                    interactionSource = source,
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(source) {
+                        source.interactions.collect { interactions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitUntil { interactions.any { it is PressInteraction.Press } }
+
+            runOnIdle { enabled = false }
+            waitForIdle()
+
+            runOnIdle {
+                val press = interactions.filterIsInstance<PressInteraction.Press>().single()
+                val cancel = interactions.filterIsInstance<PressInteraction.Cancel>().single()
+                assertSame(press, cancel.press)
+            }
+
+            target.performKeyInput { keyUp(Key.Enter) }
+            waitForIdle()
+
+            runOnIdle { assertEquals(0, clicks) }
+        }
+
+    @Test
     fun hardwareDoubleEnterInvokesDoubleClick() =
         runComposeUiTest {
             var clicks = 0

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -101,6 +102,32 @@ class ClickableFastPathTest {
 
             onNodeWithTag(TARGET_TAG).assertIsFocused().performClick()
             runOnIdle { assertEquals(1, clicks) }
+        }
+
+    @Test
+    fun disabledNonHardwareClickableHasNoFocusSemantics() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = false),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .clickable(
+                                    enabled = false,
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = {},
+                                ).testTag(TARGET_TAG),
+                    )
+                }
+            }
+
+            val semantics = onNodeWithTag(TARGET_TAG).assertIsNotEnabled().fetchSemanticsNode().config
+
+            assertFalse(semantics.contains(SemanticsProperties.Focused))
+            assertFalse(semantics.contains(SemanticsActions.RequestFocus))
         }
 
     @Test

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.foundation
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -19,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -357,6 +359,122 @@ class ClickableFastPathTest {
             waitForIdle()
 
             runOnIdle { assertEquals(0, clicks) }
+        }
+
+    @Test
+    fun removingNodeDuringHardwarePressCancelsTheCapturedSourceWithoutClicking() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var showTarget by mutableStateOf(true)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    if (showTarget) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(10.dp)
+                                    .focusRequester(requester)
+                                    .clickable(
+                                        interactionSource = source,
+                                        onClick = { clicks++ },
+                                    ).testTag(TARGET_TAG),
+                        )
+                        LaunchedEffect(requester) { requester.requestFocus() }
+                    }
+                    LaunchedEffect(source) {
+                        source.interactions.collect { interactions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitUntil { interactions.any { it is PressInteraction.Press } }
+
+            runOnIdle { showTarget = false }
+            waitForIdle()
+
+            runOnIdle {
+                val press = interactions.filterIsInstance<PressInteraction.Press>().single()
+                val cancel = interactions.filterIsInstance<PressInteraction.Cancel>().single()
+                assertSame(press, cancel.press)
+                assertEquals(0, clicks)
+            }
+        }
+
+    @Test
+    fun longClickDisablingThenReenablingDoesNotCorruptTheNextHardwarePress() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var longClicks = 0
+            var enabled by mutableStateOf(true)
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(10.dp)
+                            .focusRequester(requester)
+                            .focusable(interactionSource = source)
+                            .handleHardwareInputEnter(
+                                enabled = enabled,
+                                interactionSource = source,
+                                onLongClick = {
+                                    longClicks++
+                                    enabled = false
+                                },
+                                onClick = { clicks++ },
+                                eventRepeatCount = { event ->
+                                    if (event.key == Key.NumPadEnter) 1 else 0
+                                },
+                            ).testTag(TARGET_TAG),
+                )
+                LaunchedEffect(requester) { requester.requestFocus() }
+                LaunchedEffect(source) {
+                    source.interactions.collect { interactions += it }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput {
+                keyDown(Key.Enter)
+                keyDown(Key.NumPadEnter)
+            }
+            waitUntil { longClicks == 1 }
+            waitForIdle()
+
+            target.performKeyInput {
+                keyUp(Key.NumPadEnter)
+                keyUp(Key.Enter)
+            }
+            runOnIdle { enabled = true }
+            waitForIdle()
+
+            target.performKeyInput {
+                keyDown(Key.Enter)
+                keyUp(Key.Enter)
+            }
+            waitForIdle()
+
+            runOnIdle {
+                val presses = interactions.filterIsInstance<PressInteraction.Press>()
+                val releases = interactions.filterIsInstance<PressInteraction.Release>()
+                assertEquals(2, presses.size)
+                assertEquals(2, releases.size)
+                assertSame(presses[0], releases[0].press)
+                assertSame(presses[1], releases[1].press)
+                assertEquals(1, longClicks)
+                assertEquals(1, clicks)
+            }
         }
 
     @Test

--- a/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.foundation
 
+// Desktop-only: runComposeUiTest requires a platform host and Android local unit tests do not provide one.
+
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ dokka = "2.2.0"
 ktlint = "1.0.1"
 kotlin = "2.4.10"
 roborazzi = "1.69.0"
+robolectric = "4.16"
 spotless = "8.8.0"
 tv-foundation = "1.0.0"
 tv-material = "1.1.0"
@@ -41,6 +42,7 @@ ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 compose-rules-detekt = { module = "io.nlopez.compose.rules:detekt", version = "0.6.3" }
 tools-desugarjdklibs = "com.android.tools:desugar_jdk_libs:2.1.5"
 androidx-benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark" }

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -3,10 +3,23 @@
 The TV macrobenchmark suite compares equivalent grid items across explicit style variants:
 
 - `current_traversal`: production Wild `Modifier.clickable(style = ...)` traversable-node chain.
+- `explicit_source_fast_path`: production Wild styled clickable with one remembered, non-null
+  `MutableInteractionSource`, exercising the ordinary modifier path.
+- `null_source_compatibility`: the same styled clickable and item configuration with a null source,
+  exercising the compatibility `composed` path.
 - `candidate_composite`: benchmark-only candidate path that routes the same shared item configuration through `Container` so it can be replaced by a unified-node prototype without changing scenario setup.
 - `material_surface`: Android TV Material `Surface` baseline using matching size, colors, shape, border, scale target, item count, and deterministic focus input.
 
 The benchmark hoists the shared Wild `Style` out of lazy item bodies for the Wild variants. This keeps style construction out of the scroll measurement; add a separate microbenchmark if style construction or node creation cost is the target.
+
+`recomposeUnchangedGridWithExplicitSourceFastPath` and
+`recomposeUnchangedGridWithNullSourceCompatibility` are the directly comparable source-path pair.
+They use the same implementation, text, style, layout, item count, compilation mode, metrics, and
+focus sequence; only the interaction-source strategy differs. After every deterministic focus move,
+the benchmark injects a handled `R` key-up. Every visible item observes the same stable driver's
+snapshot generation, so the items recompose while their parameters and clickable configuration stay
+unchanged. A `SideEffect` acknowledges the generation only after item composition applies; the app
+then exposes `benchmark-recomposition-N` so the macrobenchmark waits for completion before continuing.
 
 ## Reproduction
 
@@ -14,6 +27,15 @@ Run the suite on the same physical Android TV or matching device profile for eve
 
 ```bash
 ./gradlew :internal:benchmark:connectedCheck
+```
+
+To run only the directly comparable unchanged-recomposition cases:
+
+```bash
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class="io.daio.wild.benchmark.TvBenchmarkTest#recomposeUnchangedGridWithExplicitSourceFastPath"
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class="io.daio.wild.benchmark.TvBenchmarkTest#recomposeUnchangedGridWithNullSourceCompatibility"
 ```
 
 Run at least two invocations and compare variance before making performance conclusions:
@@ -26,3 +48,7 @@ Run at least two invocations and compare variance before making performance conc
 The macrobenchmarks use warm startup, 20 measured iterations, `CompilationMode.Partial()`, `FrameTimingMetric`, and `MemoryUsageMetric(Mode.Max)`. Record the device model, Android version, build type, Compose version, compilation mode, iteration count, and item count with exported benchmark results.
 
 Report median and tail frame times, missed or overrun frames, max memory usage, and run-to-run variance. Establish a baseline before adding regression thresholds.
+
+Peak memory supports a relative allocation-pressure comparison but is not an exact allocation count.
+Use the captured traces or Android Studio's memory profiler when object-level allocation attribution is
+required; do not infer exact allocation counts from `MemoryUsageMetric` alone.

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -20,6 +20,10 @@ the benchmark injects a handled `R` key-up. Every visible item observes the same
 snapshot generation, so the items recompose while their parameters and clickable configuration stay
 unchanged. A `SideEffect` acknowledges the generation only after item composition applies; the app
 then exposes `benchmark-recomposition-N` so the macrobenchmark waits for completion before continuing.
+The optional real-wiring test observer leaves one nullable field on the shared driver and one
+lookup/null branch in each driven item. Both measured variants pay that same minimal overhead;
+detailed composition records and their marker strings are created only when the test observer is
+present.
 
 ## Reproduction
 

--- a/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
@@ -22,15 +22,19 @@ private const val DEFAULT_ITERATIONS = 20
 private const val APP_PACKAGE = "io.daio.wild.playbook.tv"
 private const val MODE_EXTRA = "MODE"
 private const val ITEMS_EXTRA = "ITEMS"
+private const val RECOMPOSITION_DRIVER_EXTRA = "RECOMPOSITION_DRIVER"
 private const val GRID_MODE = "grid"
 private const val FIRST_FOCUS_TARGET = "benchmark-item-0-0"
 private const val TERMINAL_FOCUS_TARGET = "benchmark-item-5-20"
+private const val RECOMPOSITION_MARKER_PREFIX = "benchmark-recomposition-"
 private const val FOCUS_TARGET_TIMEOUT_MS = 5_000L
 private const val INPUT_PACE_MS = 80L
 private val BENCHMARK_COMPILATION_MODE = CompilationMode.Partial()
 
 private enum class StyleVariant(val extraValue: String) {
     CurrentTraversal("current_traversal"),
+    ExplicitSourceFastPath("explicit_source_fast_path"),
+    NullSourceCompatibility("null_source_compatibility"),
     CandidateComposite("candidate_composite"),
     MaterialSurface("material_surface"),
 }
@@ -63,9 +67,28 @@ class TvBenchmarkTest {
     fun scrollGridWithMaterialSurface() {
         benchmarkRule.measureStyleVariant(StyleVariant.MaterialSurface)
     }
+
+    @Test
+    fun recomposeUnchangedGridWithExplicitSourceFastPath() {
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.ExplicitSourceFastPath,
+            enableRecompositionDriver = true,
+        )
+    }
+
+    @Test
+    fun recomposeUnchangedGridWithNullSourceCompatibility() {
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.NullSourceCompatibility,
+            enableRecompositionDriver = true,
+        )
+    }
 }
 
-private fun MacrobenchmarkRule.measureStyleVariant(variant: StyleVariant) {
+private fun MacrobenchmarkRule.measureStyleVariant(
+    variant: StyleVariant,
+    enableRecompositionDriver: Boolean = false,
+) {
     measureRepeated(
         packageName = APP_PACKAGE,
         metrics = styleMetrics(),
@@ -76,14 +99,20 @@ private fun MacrobenchmarkRule.measureStyleVariant(variant: StyleVariant) {
             startActivityAndWait {
                 it.putExtra(MODE_EXTRA, GRID_MODE)
                 it.putExtra(ITEMS_EXTRA, variant.extraValue)
+                it.putExtra(RECOMPOSITION_DRIVER_EXTRA, enableRecompositionDriver)
             }
             device.waitForIdle()
             check(device.wait(Until.hasObject(By.desc(FIRST_FOCUS_TARGET)), FOCUS_TARGET_TIMEOUT_MS)) {
                 "Timed out waiting for first benchmark focus target $FIRST_FOCUS_TARGET"
             }
+            if (enableRecompositionDriver) {
+                check(device.wait(Until.hasObject(By.desc(recompositionMarker(0))), FOCUS_TARGET_TIMEOUT_MS)) {
+                    "Timed out waiting for initial recomposition marker ${recompositionMarker(0)}"
+                }
+            }
         },
     ) {
-        device.runDeterministicFocusSequence()
+        device.runDeterministicFocusSequence(enableRecompositionDriver)
     }
 }
 
@@ -94,16 +123,36 @@ private fun styleMetrics(): List<Metric> =
         MemoryUsageMetric(MemoryUsageMetric.Mode.Max),
     )
 
-private fun UiDevice.runDeterministicFocusSequence() {
+private fun UiDevice.runDeterministicFocusSequence(enableRecompositionDriver: Boolean) {
+    var recompositionGeneration = 0
+
     pressKeyCode(KeyEvent.KEYCODE_DPAD_RIGHT)
     waitForIdle()
+    if (enableRecompositionDriver) {
+        requestUnchangedRecomposition(++recompositionGeneration)
+    }
 
     DETERMINISTIC_FOCUS_SEQUENCE.forEach { keyCode ->
         pressKeyCode(keyCode)
         waitForIdle(INPUT_PACE_MS)
+        if (enableRecompositionDriver) {
+            requestUnchangedRecomposition(++recompositionGeneration)
+        }
     }
 
     check(wait(Until.hasObject(By.desc(TERMINAL_FOCUS_TARGET)), FOCUS_TARGET_TIMEOUT_MS)) {
         "Timed out waiting for terminal benchmark focus target $TERMINAL_FOCUS_TARGET"
     }
 }
+
+private fun UiDevice.requestUnchangedRecomposition(generation: Int) {
+    check(pressKeyCode(KeyEvent.KEYCODE_R)) { "Failed to inject recomposition key" }
+    waitForIdle(INPUT_PACE_MS)
+
+    val marker = recompositionMarker(generation)
+    check(wait(Until.hasObject(By.desc(marker)), FOCUS_TARGET_TIMEOUT_MS)) {
+        "Timed out waiting for recomposition marker $marker"
+    }
+}
+
+private fun recompositionMarker(generation: Int): String = "$RECOMPOSITION_MARKER_PREFIX$generation"

--- a/layout/container/build.gradle.kts
+++ b/layout/container/build.gradle.kts
@@ -20,6 +20,18 @@ kotlin {
                 api(projects.foundations)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+            }
+        }
     }
 }
 

--- a/layout/container/src/commonMain/kotlin/io/daio/wild/container/Container.kt
+++ b/layout/container/src/commonMain/kotlin/io/daio/wild/container/Container.kt
@@ -159,8 +159,7 @@ fun Container(
     selected: Boolean? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val effectiveInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
 
     Box(
         modifier =
@@ -171,13 +170,13 @@ fun Container(
                 onClick = onClick,
                 onLongClick = onLongClick,
                 onDoubleClick = onDoubleClick,
-                interactionSource = interactionSource,
+                interactionSource = effectiveInteractionSource,
             ),
         propagateMinConstraints = true,
         content = {
-            val focused by interactionSource.collectIsFocusedAsState()
-            val pressed by interactionSource.collectIsPressedAsState()
-            val hovered by interactionSource.collectIsHoveredAsState()
+            val focused by effectiveInteractionSource.collectIsFocusedAsState()
+            val pressed by effectiveInteractionSource.collectIsPressedAsState()
+            val hovered by effectiveInteractionSource.collectIsHoveredAsState()
             ProvidesContentColor(
                 style.colors.contentColorFor(
                     enabled = enabled,

--- a/layout/container/src/commonTest/kotlin/ContainerInteractionSourceOwnershipTest.kt
+++ b/layout/container/src/commonTest/kotlin/ContainerInteractionSourceOwnershipTest.kt
@@ -1,0 +1,102 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.container
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.CompositionGroup
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ContainerInteractionSourceOwnershipTest {
+    @Test
+    fun implicitInteractionSourceIsOwnedByContainerAndStableAcrossRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            lateinit var compositionData: CompositionData
+            val ownedSources = mutableListOf<MutableInteractionSource>()
+
+            setContent {
+                generation.intValue
+                compositionData = currentComposer.compositionData
+                Container(
+                    onClick = {},
+                    modifier = Modifier.size(48.dp),
+                ) {}
+            }
+
+            runOnIdle {
+                ownedSources += compositionData.firstDirectlyOwnedInteractionSources().single()
+                generation.intValue++
+            }
+            runOnIdle {
+                val sources = compositionData.firstDirectlyOwnedInteractionSources()
+                assertEquals(1, sources.size, compositionData.dump())
+                assertTrue(compositionData.firstSourceOwnerHasDirectLayoutNode())
+                ownedSources += sources.single()
+                assertEquals(2, ownedSources.size)
+                assertSame(ownedSources.first(), ownedSources.last())
+            }
+        }
+
+    @Test
+    fun explicitInteractionSourceIsPreserved() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            var clickCount = 0
+            lateinit var compositionData: CompositionData
+
+            setContent {
+                compositionData = currentComposer.compositionData
+                Container(
+                    onClick = { clickCount++ },
+                    modifier = Modifier.testTag("container").size(48.dp),
+                    interactionSource = source,
+                ) {}
+            }
+
+            onNodeWithTag("container").performClick()
+            runOnIdle {
+                assertEquals(1, clickCount)
+                assertSame(source, compositionData.firstDirectlyOwnedInteractionSources().single())
+            }
+        }
+}
+
+private fun CompositionData.firstDirectlyOwnedInteractionSources(): List<MutableInteractionSource> =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.flatMap { group -> group.data.filterIsInstance<MutableInteractionSource>() }
+        ?.distinct()
+        .orEmpty()
+
+private fun CompositionData.firstSourceOwnerGroup(): CompositionGroup? =
+    compositionGroups.firstNotNullOfOrNull { group ->
+        group.takeIf {
+            it.compositionGroups.any { child -> child.data.any { value -> value is MutableInteractionSource } }
+        } ?: group.firstSourceOwnerGroup()
+    }
+
+private fun CompositionData.firstSourceOwnerHasDirectLayoutNode(): Boolean =
+    firstSourceOwnerGroup()
+        ?.compositionGroups
+        ?.any { group -> group.data.any { value -> value?.let { it::class.simpleName } == "LayoutNode" } }
+        ?: false
+
+private fun CompositionData.dump(depth: Int = 0): String =
+    compositionGroups.joinToString(separator = "\n") { group ->
+        "${"  ".repeat(depth)}${group.data.map { value -> value?.let { it::class.simpleName } }}\n${group.dump(depth + 1)}"
+    }

--- a/layout/container/src/commonTest/kotlin/ContainerInteractionSourceOwnershipTest.kt
+++ b/layout/container/src/commonTest/kotlin/ContainerInteractionSourceOwnershipTest.kt
@@ -9,12 +9,18 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import io.daio.wild.content.LocalContentColor
+import io.daio.wild.style.StyleDefaults
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -22,6 +28,33 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class ContainerInteractionSourceOwnershipTest {
+    @Test
+    fun implicitInteractionSourceKeepsFocusedContentColorAcrossParentRecomposition() =
+        runComposeUiTest {
+            val generation = mutableIntStateOf(0)
+            var observedContentColor = Color.Unspecified
+
+            setContent {
+                Container(
+                    onClick = {},
+                    modifier = Modifier.testTag("container-${generation.intValue}").size(48.dp),
+                    style = focusedContentStyle(),
+                ) { observedContentColor = LocalContentColor.current }
+            }
+
+            runOnIdle { assertEquals(UnfocusedContentColor, observedContentColor) }
+            onNodeWithTag("container-0")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+                .assertIsFocused()
+            waitForIdle()
+            runOnIdle { assertEquals(FocusedContentColor, observedContentColor) }
+
+            runOnIdle { generation.intValue++ }
+
+            onNodeWithTag("container-1").assertIsFocused()
+            runOnIdle { assertEquals(FocusedContentColor, observedContentColor) }
+        }
+
     @Test
     fun implicitInteractionSourceIsOwnedByContainerAndStableAcrossRecomposition() =
         runComposeUiTest {
@@ -75,6 +108,18 @@ class ContainerInteractionSourceOwnershipTest {
             }
         }
 }
+
+private val UnfocusedContentColor = Color.Red
+private val FocusedContentColor = Color.Green
+
+private fun focusedContentStyle() =
+    StyleDefaults.style(
+        colors =
+            StyleDefaults.colors(
+                contentColor = UnfocusedContentColor,
+                focusedContentColor = FocusedContentColor,
+            ),
+    )
 
 private fun CompositionData.firstDirectlyOwnedInteractionSources(): List<MutableInteractionSource> =
     firstSourceOwnerGroup()

--- a/playbook/androidTv/build.gradle.kts
+++ b/playbook/androidTv/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(compose.foundation)
     implementation(projects.layout.container)
     implementation(projects.components.button)
+
+    testImplementation(libs.junit)
 }
 
 android {

--- a/playbook/androidTv/build.gradle.kts
+++ b/playbook/androidTv/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation(projects.components.button)
 
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.ui.test.junit4)
+    debugImplementation(libs.ui.test.manifest)
 }
 
 android {
@@ -23,6 +26,23 @@ android {
         versionName = "1.0.0"
         applicationId = "io.daio.wild.playbook.tv"
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+        unitTests.all {
+            val configuredLocalRepository = System.getProperty("maven.repo.local")
+            val resolvedLocalRepository =
+                configuredLocalRepository
+                    ?.takeUnless { path -> path.isBlank() || "\${user.home}" in path }
+                    ?: "${System.getProperty("user.home")}/.m2/repository"
+            it.systemProperty(
+                "maven.repo.local",
+                resolvedLocalRepository,
+            )
+        }
     }
 
     buildTypes {

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/MainActivity.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/MainActivity.kt
@@ -11,8 +11,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val mode = intent.getStringExtra("MODE") ?: "grid"
         val items = intent.getStringExtra("ITEMS") ?: "container"
+        val enableRecompositionDriver = intent.getBooleanExtra("RECOMPOSITION_DRIVER", false)
         setContent {
-            TvLayout(itemsType = items, mode = mode)
+            TvLayout(
+                itemsType = items,
+                mode = mode,
+                enableRecompositionDriver = enableRecompositionDriver,
+            )
         }
     }
 }

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -88,7 +88,9 @@ internal fun benchmarkStyleVariant(extraValue: String): StyleVariant =
     StyleVariant.entries.firstOrNull { it.extraValue == extraValue } ?: StyleVariant.Container
 
 @Stable
-internal class BenchmarkRecompositionDriver {
+internal class BenchmarkRecompositionDriver(
+    internal val runtimeObserver: BenchmarkItemRuntimeObserver? = null,
+) {
     private val generationState = mutableIntStateOf(0)
     private val appliedGenerationState = mutableIntStateOf(0)
 
@@ -104,6 +106,30 @@ internal class BenchmarkRecompositionDriver {
         if (generation > appliedGenerationState.intValue) {
             appliedGenerationState.intValue = generation
         }
+    }
+}
+
+internal data class BenchmarkItemAppliedComposition(
+    val generation: Int,
+    val receiverModifier: Modifier,
+    val onClick: () -> Unit,
+    val style: Style,
+    val interactionSourceStrategy: BenchmarkInteractionSourceStrategy,
+    val interactionSource: MutableInteractionSource?,
+    val clickableModifier: Modifier,
+    val markerBefore: String,
+    val markerAfter: String,
+)
+
+@Stable
+internal class BenchmarkItemRuntimeObserver {
+    private val mutableAppliedCompositions = mutableListOf<BenchmarkItemAppliedComposition>()
+
+    val appliedCompositions: List<BenchmarkItemAppliedComposition>
+        get() = mutableAppliedCompositions
+
+    internal fun recordApplied(composition: BenchmarkItemAppliedComposition) {
+        mutableAppliedCompositions += composition
     }
 }
 
@@ -197,6 +223,29 @@ private fun BenchmarkLayout(
         "list" -> OptionsList(variant, modifier, recompositionDriver)
         "grid" -> OptionsGrid(variant, modifier, recompositionDriver)
     }
+}
+
+@Composable
+internal fun BenchmarkSourcePathItem(
+    variant: StyleVariant,
+    recompositionDriver: BenchmarkRecompositionDriver,
+    modifier: Modifier = Modifier,
+) {
+    require(variant.implementation == BenchmarkItemImplementation.StyledClickable)
+    val config = remember { BenchmarkItemConfig() }
+    val style = remember(config) { config.style }
+    val onClick = remember { {} }
+
+    BenchmarkItem(
+        variant = variant,
+        title = variant.benchmarkTitle,
+        style = style,
+        config = config,
+        marker = "benchmark-source-path-probe",
+        recompositionDriver = recompositionDriver,
+        onClick = onClick,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -307,26 +356,51 @@ private fun StyledClickableItem(
     recompositionDriver: BenchmarkRecompositionDriver?,
     modifier: Modifier = Modifier,
 ) {
-    if (recompositionDriver != null) {
-        // The stable driver parameter does not change. Reading its snapshot state invalidates this
-        // scope directly while every clickable argument remains unchanged, and SideEffect publishes
-        // completion only after the successful composition has been applied.
-        val recompositionGeneration = recompositionDriver.generation
-        SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
-    }
+    // The stable driver parameter does not change. Reading its snapshot state invalidates this
+    // scope directly while every clickable argument remains unchanged.
+    val recompositionGeneration = recompositionDriver?.generation
 
     val interactionSource =
         when (interactionSourceStrategy) {
             BenchmarkInteractionSourceStrategy.Explicit -> remember { MutableInteractionSource() }
             BenchmarkInteractionSourceStrategy.NullCompatibility -> null
         }
+    val clickableModifier =
+        modifier.clickable(
+            onClick = onClick,
+            interactionSource = interactionSource,
+            style = style,
+        )
+    val runtimeObserver = recompositionDriver?.runtimeObserver
+
+    if (recompositionDriver != null && recompositionGeneration != null) {
+        if (runtimeObserver == null) {
+            SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
+        } else {
+            // Observer-only values stay out of the measured null-observer path. The detailed record
+            // is published after this successful test-probe composition has been applied.
+            SideEffect {
+                val markerBefore = recompositionDriver.marker
+                recompositionDriver.acknowledgeApplied(recompositionGeneration)
+                runtimeObserver.recordApplied(
+                    BenchmarkItemAppliedComposition(
+                        generation = recompositionGeneration,
+                        receiverModifier = modifier,
+                        onClick = onClick,
+                        style = style,
+                        interactionSourceStrategy = interactionSourceStrategy,
+                        interactionSource = interactionSource,
+                        clickableModifier = clickableModifier,
+                        markerBefore = markerBefore,
+                        markerAfter = recompositionDriver.marker,
+                    ),
+                )
+            }
+        }
+    }
+
     Box(
-        modifier =
-            modifier.clickable(
-                onClick = onClick,
-                interactionSource = interactionSource,
-                style = style,
-            ),
+        modifier = clickableModifier,
     ) {
         BenchmarkItemText(title)
     }

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -14,10 +14,18 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -35,12 +43,68 @@ import androidx.tv.material3.LocalContentColor as TvLocalContentColor
 private const val GRID_ROWS = 20
 private const val GRID_COLUMNS = 100
 private const val LIST_ITEMS = 100
+private const val SOURCE_PATH_BENCHMARK_TITLE = "styled_clickable_source_path"
 
-private enum class StyleVariant(val extraValue: String) {
-    CurrentTraversal("current_traversal"),
-    CandidateComposite("candidate_composite"),
-    MaterialSurface("material_surface"),
-    Container("container"),
+internal enum class BenchmarkItemImplementation {
+    StyledClickable,
+    CandidateComposite,
+    MaterialSurface,
+}
+
+internal enum class BenchmarkInteractionSourceStrategy {
+    Explicit,
+    NullCompatibility,
+}
+
+internal enum class StyleVariant(
+    val extraValue: String,
+    val implementation: BenchmarkItemImplementation,
+    val interactionSourceStrategy: BenchmarkInteractionSourceStrategy? = null,
+    val benchmarkTitle: String = extraValue,
+) {
+    CurrentTraversal(
+        "current_traversal",
+        BenchmarkItemImplementation.StyledClickable,
+        BenchmarkInteractionSourceStrategy.Explicit,
+    ),
+    ExplicitSourceFastPath(
+        "explicit_source_fast_path",
+        BenchmarkItemImplementation.StyledClickable,
+        BenchmarkInteractionSourceStrategy.Explicit,
+        SOURCE_PATH_BENCHMARK_TITLE,
+    ),
+    NullSourceCompatibility(
+        "null_source_compatibility",
+        BenchmarkItemImplementation.StyledClickable,
+        BenchmarkInteractionSourceStrategy.NullCompatibility,
+        SOURCE_PATH_BENCHMARK_TITLE,
+    ),
+    CandidateComposite("candidate_composite", BenchmarkItemImplementation.CandidateComposite),
+    MaterialSurface("material_surface", BenchmarkItemImplementation.MaterialSurface),
+    Container("container", BenchmarkItemImplementation.CandidateComposite),
+}
+
+internal fun benchmarkStyleVariant(extraValue: String): StyleVariant =
+    StyleVariant.entries.firstOrNull { it.extraValue == extraValue } ?: StyleVariant.Container
+
+@Stable
+internal class BenchmarkRecompositionDriver {
+    private val generationState = mutableIntStateOf(0)
+    private val appliedGenerationState = mutableIntStateOf(0)
+
+    val generation: Int
+        get() = generationState.intValue
+
+    val marker: String
+        get() = "benchmark-recomposition-${appliedGenerationState.intValue}"
+
+    fun advance(): Int = ++generationState.intValue
+
+    fun acknowledgeApplied(generation: Int) {
+        if (generation > appliedGenerationState.intValue) {
+            appliedGenerationState.intValue = generation
+        }
+    }
 }
 
 private data class BenchmarkItemConfig(
@@ -88,12 +152,50 @@ fun TvLayout(
     modifier: Modifier = Modifier,
     mode: String = "list",
     itemsType: String = StyleVariant.Container.extraValue,
+    enableRecompositionDriver: Boolean = false,
 ) {
-    val variant = StyleVariant.entries.firstOrNull { it.extraValue == itemsType } ?: StyleVariant.Container
+    val variant = benchmarkStyleVariant(itemsType)
 
+    if (enableRecompositionDriver) {
+        RecompositionDrivenLayout(variant, mode, modifier)
+    } else {
+        BenchmarkLayout(variant, mode, modifier)
+    }
+}
+
+@Composable
+private fun RecompositionDrivenLayout(
+    variant: StyleVariant,
+    mode: String,
+    modifier: Modifier,
+) {
+    val driver = remember { BenchmarkRecompositionDriver() }
+    val drivenModifier =
+        modifier
+            .onPreviewKeyEvent { event ->
+                if (event.key != Key.R) {
+                    false
+                } else {
+                    if (event.type == KeyEventType.KeyUp) {
+                        driver.advance()
+                    }
+                    true
+                }
+            }.semantics { contentDescription = driver.marker }
+
+    BenchmarkLayout(variant, mode, drivenModifier, driver)
+}
+
+@Composable
+private fun BenchmarkLayout(
+    variant: StyleVariant,
+    mode: String,
+    modifier: Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
+) {
     when (mode) {
-        "list" -> OptionsList(variant, modifier)
-        "grid" -> OptionsGrid(variant, modifier)
+        "list" -> OptionsList(variant, modifier, recompositionDriver)
+        "grid" -> OptionsGrid(variant, modifier, recompositionDriver)
     }
 }
 
@@ -101,6 +203,7 @@ fun TvLayout(
 private fun OptionsGrid(
     variant: StyleVariant,
     modifier: Modifier = Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
 ) {
     val config = remember { BenchmarkItemConfig() }
     val style = remember(config) { config.style }
@@ -117,10 +220,11 @@ private fun OptionsGrid(
                 items(GRID_COLUMNS, key = { it }) { column ->
                     BenchmarkItem(
                         variant = variant,
-                        title = variant.extraValue,
+                        title = variant.benchmarkTitle,
                         style = style,
                         config = config,
                         marker = "benchmark-item-$row-$column",
+                        recompositionDriver = recompositionDriver,
                         onClick = { },
                     )
                 }
@@ -133,6 +237,7 @@ private fun OptionsGrid(
 private fun OptionsList(
     variant: StyleVariant,
     modifier: Modifier = Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
 ) {
     val config = remember { BenchmarkItemConfig() }
     val style = remember(config) { config.style }
@@ -152,10 +257,11 @@ private fun OptionsList(
         items(LIST_ITEMS, key = { it }) { index ->
             BenchmarkItem(
                 variant = variant,
-                title = variant.extraValue,
+                title = variant.benchmarkTitle,
                 style = style,
                 config = config,
                 marker = "benchmark-item-0-$index",
+                recompositionDriver = recompositionDriver,
                 onClick = { },
             )
         }
@@ -169,27 +275,51 @@ private fun BenchmarkItem(
     style: Style,
     config: BenchmarkItemConfig,
     marker: String,
+    recompositionDriver: BenchmarkRecompositionDriver?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val itemModifier = modifier.benchmarkItemMarker(marker).size(config.itemSize)
 
-    when (variant) {
-        StyleVariant.CurrentTraversal -> CurrentTraversalItem(title, onClick, style, itemModifier)
-        StyleVariant.CandidateComposite -> CandidateCompositeItem(title, onClick, style, itemModifier)
-        StyleVariant.MaterialSurface -> MaterialSurfaceItem(title, onClick, config, itemModifier)
-        StyleVariant.Container -> CandidateCompositeItem(title, onClick, style, itemModifier)
+    when (variant.implementation) {
+        BenchmarkItemImplementation.StyledClickable ->
+            StyledClickableItem(
+                title = title,
+                onClick = onClick,
+                style = style,
+                interactionSourceStrategy = checkNotNull(variant.interactionSourceStrategy),
+                recompositionDriver = recompositionDriver,
+                modifier = itemModifier,
+            )
+        BenchmarkItemImplementation.CandidateComposite ->
+            CandidateCompositeItem(title, onClick, style, itemModifier)
+        BenchmarkItemImplementation.MaterialSurface ->
+            MaterialSurfaceItem(title, onClick, config, itemModifier)
     }
 }
 
 @Composable
-private fun CurrentTraversalItem(
+private fun StyledClickableItem(
     title: String,
     onClick: () -> Unit,
     style: Style,
+    interactionSourceStrategy: BenchmarkInteractionSourceStrategy,
+    recompositionDriver: BenchmarkRecompositionDriver?,
     modifier: Modifier = Modifier,
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
+    if (recompositionDriver != null) {
+        // The stable driver parameter does not change. Reading its snapshot state invalidates this
+        // scope directly while every clickable argument remains unchanged, and SideEffect publishes
+        // completion only after the successful composition has been applied.
+        val recompositionGeneration = recompositionDriver.generation
+        SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
+    }
+
+    val interactionSource =
+        when (interactionSourceStrategy) {
+            BenchmarkInteractionSourceStrategy.Explicit -> remember { MutableInteractionSource() }
+            BenchmarkInteractionSourceStrategy.NullCompatibility -> null
+        }
     Box(
         modifier =
             modifier.clickable(

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -377,8 +377,9 @@ private fun StyledClickableItem(
         if (runtimeObserver == null) {
             SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
         } else {
-            // Observer-only values stay out of the measured null-observer path. The detailed record
-            // is published after this successful test-probe composition has been applied.
+            // Both benchmark variants share the nullable-observer lookup and branch. Detailed
+            // records and marker strings are created only by observer-enabled test probes, after
+            // the composition has been applied.
             SideEffect {
                 val markerBefore = recompositionDriver.marker
                 recompositionDriver.acknowledgeApplied(recompositionGeneration)

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -2,11 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.android.tv
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class TvBenchmarkScenarioTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
     @Test
     fun explicitAndNullSourceVariantsRouteThroughDistinctSourceStrategies() {
         val fastPath = benchmarkStyleVariant("explicit_source_fast_path")
@@ -58,4 +71,102 @@ class TvBenchmarkScenarioTest {
 
         assertEquals("benchmark-recomposition-1", driver.marker)
     }
+
+    @Test
+    fun realSourcePathItemsRecomposeWithStableInputsAndDistinctModifierRoutes() {
+        val explicitObserver = BenchmarkItemRuntimeObserver()
+        val compatibilityObserver = BenchmarkItemRuntimeObserver()
+        val explicitDriver = BenchmarkRecompositionDriver(explicitObserver)
+        val compatibilityDriver = BenchmarkRecompositionDriver(compatibilityObserver)
+        val explicitMarkersDuringComposition = mutableListOf<Pair<Int, String>>()
+        val compatibilityMarkersDuringComposition = mutableListOf<Pair<Int, String>>()
+
+        composeRule.setContent {
+            val explicitGeneration = explicitDriver.generation
+            val compatibilityGeneration = compatibilityDriver.generation
+            Box {
+                BenchmarkSourcePathItem(
+                    variant = benchmarkStyleVariant("explicit_source_fast_path"),
+                    recompositionDriver = explicitDriver,
+                )
+                BenchmarkSourcePathItem(
+                    variant = benchmarkStyleVariant("null_source_compatibility"),
+                    recompositionDriver = compatibilityDriver,
+                )
+            }
+            explicitMarkersDuringComposition += explicitGeneration to explicitDriver.marker
+            compatibilityMarkersDuringComposition += compatibilityGeneration to compatibilityDriver.marker
+        }
+
+        composeRule.runOnIdle {
+            assertSourcePathInitialApplication(
+                observer = explicitObserver,
+                expectsComposedModifier = false,
+                expectsExplicitSource = true,
+            )
+            assertSourcePathInitialApplication(
+                observer = compatibilityObserver,
+                expectsComposedModifier = true,
+                expectsExplicitSource = false,
+            )
+
+            explicitDriver.advance()
+            compatibilityDriver.advance()
+        }
+
+        composeRule.runOnIdle {
+            assertSourcePathRecomposition(
+                observer = explicitObserver,
+                driver = explicitDriver,
+                markersDuringComposition = explicitMarkersDuringComposition,
+            )
+            assertSourcePathRecomposition(
+                observer = compatibilityObserver,
+                driver = compatibilityDriver,
+                markersDuringComposition = compatibilityMarkersDuringComposition,
+            )
+        }
+    }
 }
+
+private fun assertSourcePathInitialApplication(
+    observer: BenchmarkItemRuntimeObserver,
+    expectsComposedModifier: Boolean,
+    expectsExplicitSource: Boolean,
+) {
+    assertEquals(1, observer.appliedCompositions.size)
+    assertEquals(
+        expectsComposedModifier,
+        observer.appliedCompositions.single().clickableModifier.hasComposedElement(),
+    )
+    if (expectsExplicitSource) {
+        assertTrue(observer.appliedCompositions.single().interactionSource != null)
+    } else {
+        assertNull(observer.appliedCompositions.single().interactionSource)
+    }
+}
+
+private fun assertSourcePathRecomposition(
+    observer: BenchmarkItemRuntimeObserver,
+    driver: BenchmarkRecompositionDriver,
+    markersDuringComposition: List<Pair<Int, String>>,
+) {
+    assertEquals(listOf(0, 1), observer.appliedCompositions.map { it.generation })
+
+    val initial = observer.appliedCompositions.first()
+    val recomposed = observer.appliedCompositions.last()
+    assertSame(initial.receiverModifier, recomposed.receiverModifier)
+    assertSame(initial.onClick, recomposed.onClick)
+    assertSame(initial.style, recomposed.style)
+    assertSame(initial.interactionSource, recomposed.interactionSource)
+    assertEquals(initial.interactionSourceStrategy, recomposed.interactionSourceStrategy)
+    assertTrue(1 to "benchmark-recomposition-0" in markersDuringComposition)
+    assertEquals("benchmark-recomposition-0", recomposed.markerBefore)
+    assertEquals("benchmark-recomposition-1", recomposed.markerAfter)
+    assertEquals("benchmark-recomposition-1", driver.marker)
+}
+
+private fun Modifier.hasComposedElement(): Boolean =
+    foldIn(false) { found, element ->
+        found || element::class.simpleName?.contains("ComposedModifier") == true
+    }

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -1,0 +1,61 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.android.tv
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TvBenchmarkScenarioTest {
+    @Test
+    fun explicitAndNullSourceVariantsRouteThroughDistinctSourceStrategies() {
+        val fastPath = benchmarkStyleVariant("explicit_source_fast_path")
+        val compatibilityPath = benchmarkStyleVariant("null_source_compatibility")
+
+        assertEquals(BenchmarkItemImplementation.StyledClickable, fastPath.implementation)
+        assertEquals(BenchmarkItemImplementation.StyledClickable, compatibilityPath.implementation)
+        assertEquals(fastPath.benchmarkTitle, compatibilityPath.benchmarkTitle)
+        assertEquals(BenchmarkInteractionSourceStrategy.Explicit, fastPath.interactionSourceStrategy)
+        assertEquals(
+            BenchmarkInteractionSourceStrategy.NullCompatibility,
+            compatibilityPath.interactionSourceStrategy,
+        )
+        assertNotEquals(fastPath.interactionSourceStrategy, compatibilityPath.interactionSourceStrategy)
+    }
+
+    @Test
+    fun existingBenchmarkVariantsRemainAvailable() {
+        assertEquals(
+            BenchmarkItemImplementation.StyledClickable,
+            benchmarkStyleVariant("current_traversal").implementation,
+        )
+        assertEquals(
+            BenchmarkInteractionSourceStrategy.Explicit,
+            benchmarkStyleVariant("current_traversal").interactionSourceStrategy,
+        )
+        assertEquals(
+            BenchmarkItemImplementation.CandidateComposite,
+            benchmarkStyleVariant("candidate_composite").implementation,
+        )
+        assertEquals(
+            BenchmarkItemImplementation.MaterialSurface,
+            benchmarkStyleVariant("material_surface").implementation,
+        )
+    }
+
+    @Test
+    fun recompositionDriverPublishesMarkerOnlyAfterApplication() {
+        val driver = BenchmarkRecompositionDriver()
+
+        assertEquals(0, driver.generation)
+        assertEquals("benchmark-recomposition-0", driver.marker)
+
+        assertEquals(1, driver.advance())
+        assertEquals(1, driver.generation)
+        assertEquals("benchmark-recomposition-0", driver.marker)
+
+        driver.acknowledgeApplied(1)
+
+        assertEquals("benchmark-recomposition-1", driver.marker)
+    }
+}

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -3,6 +3,7 @@
 package io.daio.android.tv
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import org.junit.Assert.assertEquals
@@ -84,6 +85,8 @@ class TvBenchmarkScenarioTest {
         composeRule.setContent {
             val explicitGeneration = explicitDriver.generation
             val compatibilityGeneration = compatibilityDriver.generation
+            val explicitMarkerDuringComposition = explicitDriver.marker
+            val compatibilityMarkerDuringComposition = compatibilityDriver.marker
             Box {
                 BenchmarkSourcePathItem(
                     variant = benchmarkStyleVariant("explicit_source_fast_path"),
@@ -94,8 +97,12 @@ class TvBenchmarkScenarioTest {
                     recompositionDriver = compatibilityDriver,
                 )
             }
-            explicitMarkersDuringComposition += explicitGeneration to explicitDriver.marker
-            compatibilityMarkersDuringComposition += compatibilityGeneration to compatibilityDriver.marker
+            SideEffect {
+                explicitMarkersDuringComposition +=
+                    explicitGeneration to explicitMarkerDuringComposition
+                compatibilityMarkersDuringComposition +=
+                    compatibilityGeneration to compatibilityMarkerDuringComposition
+            }
         }
 
         composeRule.runOnIdle {

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Clickable.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Clickable.kt
@@ -7,9 +7,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.semantics.Role
-import io.daio.wild.foundation.clickable
-import io.daio.wild.foundation.selectable
 import io.daio.wild.modifier.thenIfNotNull
+import io.daio.wild.foundation.clickable as foundationClickable
+import io.daio.wild.foundation.selectable as foundationSelectable
 
 /**
  * Interop Modifier to support either [Modifier.selectable] or [Modifier.clickable], applying
@@ -207,24 +207,17 @@ fun Modifier.clickable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.clickable(
-        enabled = enabled,
-        interactionSource = interactionSource,
-        role = role,
-        onClick = onClick,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-    ).thenIfNotNull(
-        style,
-        ifNotNullModifier = {
-            Modifier.interactionStyle(interactionSource, enabled, style = it)
-        },
-    )
-}
+): Modifier =
+    if (interactionSource != null) {
+        clickableWithStyle(enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            clickableWithStyle(enabled, rememberedInteractionSource, style, role, onLongClick, onDoubleClick, onClick)
+        }
+    }
 
 /**
  * Interop Modifier.clickable to apply the correct clickable modifier based on the requirement for
@@ -256,24 +249,25 @@ fun Modifier.experimentalClickable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.clickable(
-        enabled = enabled,
-        interactionSource = interactionSource,
-        role = role,
-        onClick = onClick,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-    ).thenIfNotNull(
-        style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(interactionSource, enabled, style = it)
-        },
-    )
-}
+): Modifier =
+    if (interactionSource != null) {
+        experimentalClickableWithStyle(enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalClickableWithStyle(
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
+            )
+        }
+    }
 
 /**
  * Interop Modifier.clickable to apply the correct clickable modifier based on the requirement for
@@ -304,24 +298,25 @@ fun Modifier.experimentalClickable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.clickable(
-        enabled = enabled,
-        interactionSource = interactionSource,
-        role = role,
-        onClick = onClick,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-    ).thenIfNotNull(
-        style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(interactionSource, enabled, block = it)
-        },
-    )
-}
+): Modifier =
+    if (interactionSource != null) {
+        experimentalClickableWithStyle(enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalClickableWithStyle(
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
+            )
+        }
+    }
 
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
@@ -350,30 +345,26 @@ fun Modifier.selectable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.selectable(
-        selected = selected,
-        enabled = enabled,
-        interactionSource = interactionSource,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-        role = role,
-        onClick = onClick,
-    ).thenIfNotNull(
-        value = style,
-        ifNotNullModifier = {
-            Modifier.interactionStyle(
-                style = it,
-                interactionSource = interactionSource,
-                enabled = enabled,
-                selected = selected,
+): Modifier =
+    if (interactionSource != null) {
+        selectableWithStyle(selected, enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            selectableWithStyle(
+                selected,
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
             )
-        },
-    )
-}
+        }
+    }
 
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
@@ -407,11 +398,107 @@ fun Modifier.experimentalSelectable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+): Modifier =
+    if (interactionSource != null) {
+        experimentalSelectableWithStyle(
+            selected,
+            enabled,
+            interactionSource,
+            style,
+            role,
+            onLongClick,
+            onDoubleClick,
+            onClick,
+        )
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalSelectableWithStyle(
+                selected,
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
+            )
+        }
+    }
 
-    Modifier.selectable(
+private fun Modifier.clickableWithStyle(
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationClickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.interactionStyle(interactionSource, enabled, style = it)
+    })
+
+private fun Modifier.experimentalClickableWithStyle(
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationClickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(interactionSource, enabled, style = it)
+    })
+
+private fun Modifier.experimentalClickableWithStyle(
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: (StyleScope.() -> Unit)?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationClickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(interactionSource, enabled, block = it)
+    })
+
+private fun Modifier.selectableWithStyle(
+    selected: Boolean,
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationSelectable(
         selected = selected,
         enabled = enabled,
         interactionSource = interactionSource,
@@ -419,18 +506,68 @@ fun Modifier.experimentalSelectable(
         onDoubleClick = onDoubleClick,
         role = role,
         onClick = onClick,
-    ).thenIfNotNull(
-        value = style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(
-                style = it,
-                interactionSource = interactionSource,
-                enabled = enabled,
-                selected = selected,
-            )
-        },
-    )
-}
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.interactionStyle(
+            style = it,
+            interactionSource = interactionSource,
+            enabled = enabled,
+            selected = selected,
+        )
+    })
+
+private fun Modifier.experimentalSelectableWithStyle(
+    selected: Boolean,
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationSelectable(
+        selected = selected,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+        role = role,
+        onClick = onClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(
+            style = it,
+            interactionSource = interactionSource,
+            enabled = enabled,
+            selected = selected,
+        )
+    })
+
+private fun Modifier.experimentalSelectableWithStyle(
+    selected: Boolean,
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: (StyleScope.() -> Unit)?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationSelectable(
+        selected = selected,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+        role = role,
+        onClick = onClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(
+            block = it,
+            interactionSource = interactionSource,
+            enabled = enabled,
+            selected = selected,
+        )
+    })
 
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
@@ -462,27 +599,32 @@ fun Modifier.experimentalSelectable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.selectable(
-        selected = selected,
-        enabled = enabled,
-        interactionSource = interactionSource,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-        role = role,
-        onClick = onClick,
-    ).thenIfNotNull(
-        value = style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(
-                block = it,
-                interactionSource = interactionSource,
-                enabled = enabled,
-                selected = selected,
+): Modifier =
+    if (interactionSource != null) {
+        experimentalSelectableWithStyle(
+            selected,
+            enabled,
+            interactionSource,
+            style,
+            role,
+            onLongClick,
+            onDoubleClick,
+            onClick,
+        )
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalSelectableWithStyle(
+                selected,
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
             )
-        },
-    )
-}
+        }
+    }

--- a/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
+++ b/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
@@ -1,0 +1,153 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+@file:Suppress("DEPRECATION")
+
+package io.daio.wild.style
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.materialize
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import io.daio.wild.style.modifiers.InteractionSourceElement
+import io.daio.wild.style.modifiers.StyleRecorder
+import io.daio.wild.style.modifiers.recordStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ClickableFastPathTest {
+    @Test
+    fun currentAndDeprecatedNonNullSourceOverloadsUseOrdinaryModifierChains() {
+        val source = MutableInteractionSource()
+        val block: StyleScope.() -> Unit = {}
+
+        val modifiers =
+            listOf(
+                Modifier.clickable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.selectable(true, interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.interactable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.interactable(selected = true, interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalClickable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalClickable(interactionSource = source, style = block, onClick = {}),
+                Modifier.experimentalSelectable(true, interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalSelectable(true, interactionSource = source, style = block, onClick = {}),
+                Modifier.experimentalInteractable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalInteractable(interactionSource = source, style = block, onClick = {}),
+                Modifier.experimentalInteractable(
+                    selected = true,
+                    interactionSource = source,
+                    style = StyleDefaults.None,
+                    onClick = {},
+                ),
+                Modifier.experimentalInteractable(
+                    selected = true,
+                    interactionSource = source,
+                    style = block,
+                    onClick = {},
+                ),
+            )
+
+        modifiers.forEach { modifier ->
+            assertFalse(modifier.hasComposedElement(), "Unexpected composed element in $modifier")
+            assertSame(source, modifier.interactionSourceElement()?.interactionSource)
+        }
+    }
+
+    @Test
+    fun receiverStaysFirstAndNullStyleAddsNoStyleObserver() {
+        val source = MutableInteractionSource()
+        val modifier =
+            (Modifier then ReceiverMarker).clickable(
+                interactionSource = source,
+                style = null,
+                onClick = {},
+            )
+
+        val elements = modifier.elements()
+
+        assertTrue(elements.size > 1)
+        assertSame(ReceiverMarker, elements.first())
+        assertFalse(modifier.hasComposedElement())
+        assertSame(null, modifier.interactionSourceElement())
+    }
+
+    @Test
+    fun nullSourceRemembersOneSourceAcrossRecomposition() =
+        runComposeUiTest {
+            val capturedSources = mutableListOf<Any?>()
+            var generation by mutableIntStateOf(0)
+
+            setContent {
+                generation
+                val materialized =
+                    currentComposer.materialize(
+                        Modifier.clickable(
+                            interactionSource = null,
+                            style = StyleDefaults.None,
+                            onClick = {},
+                        ),
+                    )
+                SideEffect {
+                    capturedSources += materialized.interactionSourceElement()?.interactionSource
+                }
+                Box(modifier = materialized)
+            }
+
+            runOnIdle { generation++ }
+            runOnIdle {
+                assertEquals(2, capturedSources.size)
+                assertNotNull(capturedSources.first())
+                assertSame(capturedSources.first(), capturedSources.last())
+            }
+        }
+
+    @Test
+    fun injectedSourceDrivesStyleObservation() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val recorder = StyleRecorder()
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .clickable(
+                                interactionSource = source,
+                                style = StyleDefaults.None,
+                                onClick = {},
+                            ).recordStyle(recorder),
+                )
+            }
+
+            runOnIdle {
+                assertTrue(source.tryEmit(PressInteraction.Press(Offset.Zero)))
+            }
+            runOnIdle { assertTrue(recorder.last.pressed) }
+        }
+}
+
+private data object ReceiverMarker : Modifier.Element
+
+private fun Modifier.hasComposedElement(): Boolean =
+    elements().any { element -> element::class.simpleName?.contains("ComposedModifier") == true }
+
+private fun Modifier.interactionSourceElement(): InteractionSourceElement? =
+    elements().filterIsInstance<InteractionSourceElement>().firstOrNull()
+
+private fun Modifier.elements(): List<Modifier.Element> =
+    buildList {
+        foldIn(Unit) { _, element -> add(element) }
+    }

--- a/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
+++ b/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
@@ -5,18 +5,22 @@
 package io.daio.wild.style
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.materialize
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
 import io.daio.wild.style.modifiers.InteractionSourceElement
 import io.daio.wild.style.modifiers.StyleRecorder
 import io.daio.wild.style.modifiers.recordStyle
@@ -115,7 +119,7 @@ class ClickableFastPathTest {
         }
 
     @Test
-    fun injectedSourceDrivesStyleObservation() =
+    fun focusInputThroughInjectedSourceDrivesStyleObservation() =
         runComposeUiTest {
             val source = MutableInteractionSource()
             val recorder = StyleRecorder()
@@ -124,20 +128,25 @@ class ClickableFastPathTest {
                 Box(
                     modifier =
                         Modifier
+                            .size(10.dp)
                             .clickable(
                                 interactionSource = source,
                                 style = StyleDefaults.None,
                                 onClick = {},
-                            ).recordStyle(recorder),
+                            ).recordStyle(recorder)
+                            .testTag(TARGET_TAG),
                 )
             }
 
-            runOnIdle {
-                assertTrue(source.tryEmit(PressInteraction.Press(Offset.Zero)))
-            }
-            runOnIdle { assertTrue(recorder.last.pressed) }
+            onNodeWithTag(TARGET_TAG)
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+            waitForIdle()
+
+            runOnIdle { assertTrue(recorder.last.focused) }
         }
 }
+
+private const val TARGET_TAG = "target"
 
 private data object ReceiverMarker : Modifier.Element
 


### PR DESCRIPTION
## Summary

- bypass `composed` for styled clickable/selectable calls with an explicit interaction source, while retaining the null-source compatibility fallback
- give interactive components one remembered interaction source shared across input, styling, and content-color observation
- preserve hardware focus/key semantics and balance press/focus interactions across source replacement, disable, reset, and detach
- add recomposition benchmark variants and regression coverage for fast-path routing, source ownership, lifecycle behavior, and benchmark wiring

Linear: https://linear.app/the-good-egg-studio/issue/THE-220/remove-composed-from-styled-clickableselectable-fast-paths

## Verification

- affected Android/JVM tests passed for foundations, style, container, button, toggleable, list-item, and the Android TV playbook
- Android TV debug/release and benchmark APK/test assemblies passed
- `spotlessCheck`, `detekt`, and `lint` passed
- Metalava compatibility passed for all affected published modules
- final post-rebase verification completed successfully (750 actionable Gradle tasks)

## Limitations

- connected macrobenchmarks were not run because no Android device or emulator is available; this PR makes no frame-time, memory, or physical-TV performance claims
- repository-wide `./gradlew build` reaches an existing `:style:compileTestKotlinJs` failure because unchanged common tests import `kotlinx.coroutines.runBlocking` without a JS test dependency; the same failure was reproduced on `origin/main` at `78b7e73`