### PR TITLE
perf: remove composed interaction fast paths (THE-220) [1/3]

### DIFF
--- a/foundations/build.gradle.kts
+++ b/foundations/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright 2024, Dai Williams
 // SPDX-License-Identifier: Apache-2.0
+@file:OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+
 plugins {
     id("io.daio.compose")
     id("io.daio.android.library")
@@ -19,6 +21,18 @@ kotlin {
             dependencies {
                 implementation(compose.foundation)
                 implementation(projects.modifier)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(compose.uiTest)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
             }
         }
     }

--- a/foundations/build.gradle.kts
+++ b/foundations/build.gradle.kts
@@ -24,14 +24,10 @@ kotlin {
             }
         }
 
-        commonTest {
+        val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(compose.uiTest)
-            }
-        }
-        val jvmTest by getting {
-            dependencies {
                 implementation(compose.desktop.currentOs)
             }
         }

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -579,9 +579,10 @@ private class HardwareEnterKeyEventNode(
                 !observePlatformInteractions ||
                 currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
-        if (previouslyRequiredHardwareInput && !hardwareInputRequired && activePress != null) {
+        if (previouslyRequiredHardwareInput && !hardwareInputRequired) {
             resetDoubleClick()
-            releasePressInteraction()
+            isLongClick = false
+            if (activePress != null) releasePressInteraction()
         }
         invalidateSemantics()
         invalidateFocusProperties()

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -422,6 +422,7 @@ internal fun Modifier.handleHardwareInputEnter(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
+    observePlatformInteractions: Boolean = false,
     eventRepeatCount: ((KeyEvent) -> Int)? = null,
 ): Modifier =
     this then
@@ -431,6 +432,7 @@ internal fun Modifier.handleHardwareInputEnter(
             onClick = onClick,
             onLongClick = onLongClick,
             onDoubleClick = onDoubleClick,
+            observePlatformInteractions = observePlatformInteractions,
             eventRepeatCount = eventRepeatCount,
         )
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -8,16 +8,18 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusEventModifierNode
+import androidx.compose.ui.focus.FocusProperties
+import androidx.compose.ui.focus.FocusPropertiesModifierNode
 import androidx.compose.ui.focus.FocusState
-import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.FocusTargetModifierNode
+import androidx.compose.ui.focus.Focusability
+import androidx.compose.ui.focus.invalidateFocusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -25,19 +27,24 @@ import androidx.compose.ui.input.key.KeyInputModifierNode
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.SemanticsModifierNode
 import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateSemantics
+import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.focused
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.onLongClick
+import androidx.compose.ui.semantics.requestFocus
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
-import io.daio.wild.modifier.thenIf
-import io.daio.wild.modifier.thenIfNotNull
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -314,82 +321,130 @@ private fun Modifier.handleTvInputIfRequired(
     onDoubleClick: (() -> Unit)? = null,
     onClickLabel: String? = null,
     onClick: (() -> Unit),
-) = this.composed {
-    val hardwareInputDevice = LocalPlatformInteractions.current.requiresHardwareInput
-    // On Tv we disable click actions but maintain focusable to ensure navigation through UI.
-    val focusEnabled = enabled || hardwareInputDevice
+) = this then PlatformFocusableElement(enabled, interactionSource) then
+    HardwareEnterKeyElement(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+        observePlatformInteractions = true,
+        selected = selected,
+        role = role,
+        onLongClickLabel = onLongClickLabel,
+        onClickLabel = onClickLabel,
+    )
 
-    this.focusable(enabled = focusEnabled, interactionSource = interactionSource)
-        .thenIf(
-            condition = hardwareInputDevice,
-            ifTrueModifier =
-                Modifier.handleHardwareInputEnter(
-                    enabled = enabled,
-                    interactionSource = interactionSource,
-                    onClick = onClick,
-                    onLongClick = onLongClick,
-                    onDoubleClick = onDoubleClick,
-                ).hardwareSemantics(
-                    enabled = enabled,
-                    selected = selected,
-                    role = role,
-                    interactionSource = interactionSource,
-                    onLongClickLabel = onLongClickLabel,
-                    onLongClick = onLongClick,
-                    onClickLabel = onClickLabel,
-                    onClick = onClick,
-                ).focusProperties {
-                    // Since we already configure the node to be focusable we want to ensure any
-                    // modifiers applied after that create new focusable Nodes can not be focused.
-                    // This ensures the Composable can not be focused if the component itself has
-                    // canFocus disabled.
-                    canFocus = false
-                },
-        )
+private data class PlatformFocusableElement(
+    val enabled: Boolean,
+    val interactionSource: MutableInteractionSource?,
+) : ModifierNodeElement<PlatformFocusableNode>() {
+    override fun create(): PlatformFocusableNode = PlatformFocusableNode(enabled, interactionSource)
+
+    override fun update(node: PlatformFocusableNode) {
+        node.update(enabled, interactionSource)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "platformFocusable"
+        properties["enabled"] = enabled
+        properties["interactionSource"] = interactionSource
+    }
 }
 
-private fun Modifier.hardwareSemantics(
-    enabled: Boolean,
-    role: Role?,
-    interactionSource: MutableInteractionSource?,
-    indication: Indication? = null,
-    selected: Boolean? = null,
-    onLongClickLabel: String? = null,
-    onLongClick: (() -> Unit)? = null,
-    onClickLabel: String? = null,
-    onClick: (() -> Unit)? = null,
-): Modifier =
-    this.semantics(mergeDescendants = true) {
-        if (selected != null) {
-            this.selected = selected
-        }
+@OptIn(ExperimentalWildApi::class)
+private class PlatformFocusableNode(
+    private var enabled: Boolean,
+    private var interactionSource: MutableInteractionSource?,
+) : DelegatingNode(),
+    CompositionLocalConsumerModifierNode,
+    ObserverModifierNode,
+    SemanticsModifierNode {
+    private val focusTarget =
+        delegate(
+            FocusTargetModifierNode(
+                focusability = Focusability.Never,
+                onFocusChange = ::onFocusChange,
+            ),
+        )
+    private var focusInteraction: FocusInteraction.Focus? = null
+    private var focusEnabled = false
 
-        if (role != null) {
-            this.role = role
+    override fun onAttach() {
+        updateFocusability()
+    }
+
+    override fun onObservedReadsChanged() {
+        updateFocusability()
+    }
+
+    fun update(
+        enabled: Boolean,
+        interactionSource: MutableInteractionSource?,
+    ) {
+        if (this.interactionSource !== interactionSource) {
+            disposeFocusInteraction()
+            this.interactionSource = interactionSource
+            if (focusTarget.focusState.isFocused) emitFocusInteraction()
         }
-        onClick(label = onClickLabel) {
-            onClick?.let { nnOnClick ->
-                nnOnClick()
-                return@onClick true
+        if (this.enabled != enabled) {
+            this.enabled = enabled
+            if (isAttached) updateFocusability()
+        }
+    }
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        if (focusEnabled) {
+            focused = focusTarget.focusState.isFocused
+            requestFocus { focusTarget.requestFocus() }
+        }
+    }
+
+    override fun onDetach() {
+        disposeFocusInteraction()
+    }
+
+    private fun updateFocusability() {
+        var requiresHardwareInput = false
+        observeReads {
+            requiresHardwareInput = currentValueOf(LocalPlatformInteractions).requiresHardwareInput
+        }
+        focusEnabled = enabled || requiresHardwareInput
+        focusTarget.focusability =
+            if (focusEnabled) {
+                Focusability.Always
+            } else {
+                Focusability.Never
             }
-            false
+        invalidateSemantics()
+    }
+
+    private fun onFocusChange(
+        previous: FocusState,
+        current: FocusState,
+    ) {
+        if (previous.isFocused == current.isFocused) return
+        if (current.isFocused) {
+            emitFocusInteraction()
+        } else {
+            disposeFocusInteraction()
         }
-        onLongClick(label = onLongClickLabel) {
-            onLongClick?.let { nnOnLongClick ->
-                nnOnLongClick()
-                return@onLongClick true
-            }
-            false
+        invalidateSemantics()
+    }
+
+    private fun emitFocusInteraction() {
+        val interaction = FocusInteraction.Focus()
+        focusInteraction = interaction
+        coroutineScope.launch { interactionSource?.emit(interaction) }
+    }
+
+    private fun disposeFocusInteraction() {
+        focusInteraction?.let { interaction ->
+            interactionSource?.tryEmit(FocusInteraction.Unfocus(interaction))
         }
-        if (!enabled) {
-            disabled()
-        }
-    }.thenIfNotNull(
-        value = interactionSource,
-        ifNotNullModifier = { interactionSource ->
-            Modifier.indication(interactionSource, indication)
-        },
-    )
+        focusInteraction = null
+    }
+}
 
 /**
  * Modifier to set up handling of hardware input enter keys, such as Tv remote Dpad enter and
@@ -404,11 +459,11 @@ internal fun Modifier.handleHardwareInputEnter(
 ): Modifier =
     this then
         HardwareEnterKeyElement(
-            enabled,
-            interactionSource,
-            onClick,
-            onLongClick,
-            onDoubleClick,
+            enabled = enabled,
+            interactionSource = interactionSource,
+            onClick = onClick,
+            onLongClick = onLongClick,
+            onDoubleClick = onDoubleClick,
         )
 
 private data class HardwareEnterKeyElement(
@@ -417,6 +472,11 @@ private data class HardwareEnterKeyElement(
     val onClick: (() -> Unit)? = null,
     val onLongClick: (() -> Unit)? = null,
     val onDoubleClick: (() -> Unit)? = null,
+    val observePlatformInteractions: Boolean = false,
+    val selected: Boolean? = null,
+    val role: Role? = null,
+    val onLongClickLabel: String? = null,
+    val onClickLabel: String? = null,
 ) : ModifierNodeElement<HardwareEnterKeyEventNode>() {
     override fun create(): HardwareEnterKeyEventNode =
         HardwareEnterKeyEventNode(
@@ -425,6 +485,11 @@ private data class HardwareEnterKeyElement(
             onClick = onClick,
             onLongClick = onLongClick,
             onDoubleClick = onDoubleClick,
+            observePlatformInteractions = observePlatformInteractions,
+            selected = selected,
+            role = role,
+            onLongClickLabel = onLongClickLabel,
+            onClickLabel = onClickLabel,
         )
 
     override fun update(node: HardwareEnterKeyEventNode) {
@@ -433,6 +498,12 @@ private data class HardwareEnterKeyElement(
         node.onClick = onClick
         node.onLongClick = onLongClick
         node.onDoubleClick = onDoubleClick
+        node.observePlatformInteractions = observePlatformInteractions
+        node.selected = selected
+        node.role = role
+        node.onLongClickLabel = onLongClickLabel
+        node.onClickLabel = onClickLabel
+        if (node.isAttached) node.updatePlatformConfiguration()
     }
 
     override fun InspectorInfo.inspectableProperties() {
@@ -442,6 +513,11 @@ private data class HardwareEnterKeyElement(
         properties["onClick"] = onClick
         properties["onLongClick"] = onLongClick
         properties["onDoubleClick"] = onDoubleClick
+        properties["observePlatformInteractions"] = observePlatformInteractions
+        properties["selected"] = selected
+        properties["role"] = role
+        properties["onLongClickLabel"] = onLongClickLabel
+        properties["onClickLabel"] = onClickLabel
     }
 }
 
@@ -451,10 +527,18 @@ private class HardwareEnterKeyEventNode(
     var onLongClick: (() -> Unit)? = null,
     var onDoubleClick: (() -> Unit)? = null,
     var interactionSource: MutableInteractionSource?,
+    var observePlatformInteractions: Boolean = false,
+    var selected: Boolean? = null,
+    var role: Role? = null,
+    var onLongClickLabel: String? = null,
+    var onClickLabel: String? = null,
     var timeNow: () -> Instant = { Clock.System.now() },
 ) : KeyInputModifierNode,
     FocusEventModifierNode,
     CompositionLocalConsumerModifierNode,
+    ObserverModifierNode,
+    SemanticsModifierNode,
+    FocusPropertiesModifierNode,
     Modifier.Node() {
     private val pressInteraction = PressInteraction.Press(Offset.Zero)
     private var focusState: FocusState? = null
@@ -466,14 +550,58 @@ private class HardwareEnterKeyEventNode(
     private var awaitingSecondClick: Boolean = false
     private var doubleClickTimeoutJob: Job? = null
     private var doubleClickTimeout: Duration = 300.milliseconds
+    private var hardwareInputRequired: Boolean = !observePlatformInteractions
 
     override fun onAttach() {
-        doubleClickTimeout =
-            currentValueOf(LocalViewConfiguration).doubleTapTimeoutMillis.milliseconds
+        updatePlatformConfiguration()
+    }
+
+    override fun onObservedReadsChanged() {
+        updatePlatformConfiguration()
+    }
+
+    @OptIn(ExperimentalWildApi::class)
+    fun updatePlatformConfiguration() {
+        val previouslyRequiredHardwareInput = hardwareInputRequired
+        observeReads {
+            doubleClickTimeout =
+                currentValueOf(LocalViewConfiguration).doubleTapTimeoutMillis.milliseconds
+            hardwareInputRequired =
+                !observePlatformInteractions ||
+                currentValueOf(LocalPlatformInteractions).requiresHardwareInput
+        }
+        if (previouslyRequiredHardwareInput && !hardwareInputRequired && pressed) {
+            resetDoubleClick()
+            releasePressInteraction()
+        }
+        invalidateSemantics()
+        invalidateFocusProperties()
+    }
+
+    override fun applyFocusProperties(focusProperties: FocusProperties) {
+        if (hardwareInputRequired) {
+            focusProperties.canFocus = false
+        }
+    }
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        if (!observePlatformInteractions || !hardwareInputRequired) return
+
+        this@HardwareEnterKeyEventNode.selected?.let { selected = it }
+        this@HardwareEnterKeyEventNode.role?.let { role = it }
+        onClick(label = onClickLabel) {
+            this@HardwareEnterKeyEventNode.onClick?.invoke()
+            this@HardwareEnterKeyEventNode.onClick != null
+        }
+        onLongClick(label = onLongClickLabel) {
+            this@HardwareEnterKeyEventNode.onLongClick?.invoke()
+            this@HardwareEnterKeyEventNode.onLongClick != null
+        }
+        if (!enabled) disabled()
     }
 
     override fun onKeyEvent(event: KeyEvent): Boolean {
-        if (HardwareEnterKeys.contains(event.key.keyCode) && enabled) {
+        if (hardwareInputRequired && HardwareEnterKeys.contains(event.key.keyCode) && enabled) {
             when (event.type) {
                 KeyEventType.KeyDown -> {
                     when (event.repeatCount) {

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -422,6 +422,7 @@ internal fun Modifier.handleHardwareInputEnter(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
+    eventRepeatCount: ((KeyEvent) -> Int)? = null,
 ): Modifier =
     this then
         HardwareEnterKeyElement(
@@ -430,6 +431,7 @@ internal fun Modifier.handleHardwareInputEnter(
             onClick = onClick,
             onLongClick = onLongClick,
             onDoubleClick = onDoubleClick,
+            eventRepeatCount = eventRepeatCount,
         )
 
 private data class HardwareEnterKeyElement(
@@ -443,6 +445,7 @@ private data class HardwareEnterKeyElement(
     val role: Role? = null,
     val onLongClickLabel: String? = null,
     val onClickLabel: String? = null,
+    val eventRepeatCount: ((KeyEvent) -> Int)? = null,
 ) : ModifierNodeElement<HardwareEnterKeyEventNode>() {
     override fun create(): HardwareEnterKeyEventNode =
         HardwareEnterKeyEventNode(
@@ -456,6 +459,7 @@ private data class HardwareEnterKeyElement(
             role = role,
             onLongClickLabel = onLongClickLabel,
             onClickLabel = onClickLabel,
+            eventRepeatCount = eventRepeatCount,
         )
 
     override fun update(node: HardwareEnterKeyEventNode) {
@@ -470,6 +474,7 @@ private data class HardwareEnterKeyElement(
             role = role,
             onLongClickLabel = onLongClickLabel,
             onClickLabel = onClickLabel,
+            eventRepeatCount = eventRepeatCount,
         )
     }
 
@@ -485,6 +490,7 @@ private data class HardwareEnterKeyElement(
         properties["role"] = role
         properties["onLongClickLabel"] = onLongClickLabel
         properties["onClickLabel"] = onClickLabel
+        properties["eventRepeatCount"] = eventRepeatCount
     }
 }
 
@@ -499,6 +505,7 @@ private class HardwareEnterKeyEventNode(
     private var role: Role? = null,
     private var onLongClickLabel: String? = null,
     private var onClickLabel: String? = null,
+    private var eventRepeatCount: ((KeyEvent) -> Int)? = null,
     var timeNow: () -> Instant = { Clock.System.now() },
 ) : KeyInputModifierNode,
     FocusEventModifierNode,
@@ -534,10 +541,10 @@ private class HardwareEnterKeyEventNode(
         role: Role?,
         onLongClickLabel: String?,
         onClickLabel: String?,
+        eventRepeatCount: ((KeyEvent) -> Int)?,
     ) {
-        if (activePress != null && (!enabled || interactionSource !== this.interactionSource)) {
-            resetDoubleClick()
-            cancelPressInteraction()
+        if (!enabled || (activePress != null && interactionSource !== this.interactionSource)) {
+            terminateGesture()
         }
 
         this.enabled = enabled
@@ -550,6 +557,7 @@ private class HardwareEnterKeyEventNode(
         this.role = role
         this.onLongClickLabel = onLongClickLabel
         this.onClickLabel = onClickLabel
+        this.eventRepeatCount = eventRepeatCount
         if (isAttached) updatePlatformConfiguration()
     }
 
@@ -605,7 +613,7 @@ private class HardwareEnterKeyEventNode(
         if (hardwareInputRequired && HardwareEnterKeys.contains(event.key.keyCode) && enabled) {
             when (event.type) {
                 KeyEventType.KeyDown -> {
-                    when (event.repeatCount) {
+                    when (eventRepeatCount?.invoke(event) ?: event.repeatCount) {
                         0 -> {
                             // If we are handling double clicks we should check if this
                             // key down event is potentially a second click.
@@ -636,8 +644,7 @@ private class HardwareEnterKeyEventNode(
                             onClick?.invoke()
                         }
                     } else {
-                        activePress = null
-                        isLongClick = false
+                        terminateGesture()
                     }
                 }
             }
@@ -661,11 +668,11 @@ private class HardwareEnterKeyEventNode(
     }
 
     override fun onReset() {
-        reset()
+        terminateGesture(synchronously = true)
     }
 
     override fun onDetach() {
-        reset()
+        terminateGesture(synchronously = true)
     }
 
     private fun emitPressInteraction() {
@@ -686,12 +693,16 @@ private class HardwareEnterKeyEventNode(
         }
     }
 
-    private fun cancelPressInteraction() {
+    private fun cancelPressInteraction(synchronously: Boolean) {
         val press = activePress ?: return
         activePress = null
-        isLongClick = false
-        coroutineScope.launch {
-            press.interactionSource?.emit(PressInteraction.Cancel(press.interaction))
+        val cancel = PressInteraction.Cancel(press.interaction)
+        if (synchronously) {
+            press.interactionSource?.tryEmit(cancel)
+        } else {
+            coroutineScope.launch {
+                press.interactionSource?.emit(cancel)
+            }
         }
     }
 
@@ -742,9 +753,9 @@ private class HardwareEnterKeyEventNode(
         }
     }
 
-    private fun reset() {
+    private fun terminateGesture(synchronously: Boolean = false) {
         resetDoubleClick()
-        activePress = null
+        cancelPressInteraction(synchronously)
         isLongClick = false
     }
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -459,17 +459,18 @@ private data class HardwareEnterKeyElement(
         )
 
     override fun update(node: HardwareEnterKeyEventNode) {
-        node.enabled = enabled
-        node.interactionSource = interactionSource
-        node.onClick = onClick
-        node.onLongClick = onLongClick
-        node.onDoubleClick = onDoubleClick
-        node.observePlatformInteractions = observePlatformInteractions
-        node.selected = selected
-        node.role = role
-        node.onLongClickLabel = onLongClickLabel
-        node.onClickLabel = onClickLabel
-        if (node.isAttached) node.updatePlatformConfiguration()
+        node.update(
+            enabled = enabled,
+            interactionSource = interactionSource,
+            onClick = onClick,
+            onLongClick = onLongClick,
+            onDoubleClick = onDoubleClick,
+            observePlatformInteractions = observePlatformInteractions,
+            selected = selected,
+            role = role,
+            onLongClickLabel = onLongClickLabel,
+            onClickLabel = onClickLabel,
+        )
     }
 
     override fun InspectorInfo.inspectableProperties() {
@@ -488,16 +489,16 @@ private data class HardwareEnterKeyElement(
 }
 
 private class HardwareEnterKeyEventNode(
-    var enabled: Boolean,
-    var onClick: (() -> Unit)? = null,
-    var onLongClick: (() -> Unit)? = null,
-    var onDoubleClick: (() -> Unit)? = null,
-    var interactionSource: MutableInteractionSource?,
-    var observePlatformInteractions: Boolean = false,
-    var selected: Boolean? = null,
-    var role: Role? = null,
-    var onLongClickLabel: String? = null,
-    var onClickLabel: String? = null,
+    private var enabled: Boolean,
+    private var onClick: (() -> Unit)? = null,
+    private var onLongClick: (() -> Unit)? = null,
+    private var onDoubleClick: (() -> Unit)? = null,
+    private var interactionSource: MutableInteractionSource?,
+    private var observePlatformInteractions: Boolean = false,
+    private var selected: Boolean? = null,
+    private var role: Role? = null,
+    private var onLongClickLabel: String? = null,
+    private var onClickLabel: String? = null,
     var timeNow: () -> Instant = { Clock.System.now() },
 ) : KeyInputModifierNode,
     FocusEventModifierNode,
@@ -506,9 +507,13 @@ private class HardwareEnterKeyEventNode(
     SemanticsModifierNode,
     FocusPropertiesModifierNode,
     Modifier.Node() {
-    private val pressInteraction = PressInteraction.Press(Offset.Zero)
+    private data class ActivePress(
+        val interaction: PressInteraction.Press,
+        val interactionSource: MutableInteractionSource?,
+    )
+
     private var focusState: FocusState? = null
-    private var pressed: Boolean = false
+    private var activePress: ActivePress? = null
     private var isLongClick: Boolean = false
 
     // Double-click state
@@ -517,6 +522,36 @@ private class HardwareEnterKeyEventNode(
     private var doubleClickTimeoutJob: Job? = null
     private var doubleClickTimeout: Duration = 300.milliseconds
     private var hardwareInputRequired: Boolean = !observePlatformInteractions
+
+    fun update(
+        enabled: Boolean,
+        interactionSource: MutableInteractionSource?,
+        onClick: (() -> Unit)?,
+        onLongClick: (() -> Unit)?,
+        onDoubleClick: (() -> Unit)?,
+        observePlatformInteractions: Boolean,
+        selected: Boolean?,
+        role: Role?,
+        onLongClickLabel: String?,
+        onClickLabel: String?,
+    ) {
+        if (activePress != null && (!enabled || interactionSource !== this.interactionSource)) {
+            resetDoubleClick()
+            cancelPressInteraction()
+        }
+
+        this.enabled = enabled
+        this.interactionSource = interactionSource
+        this.onClick = onClick
+        this.onLongClick = onLongClick
+        this.onDoubleClick = onDoubleClick
+        this.observePlatformInteractions = observePlatformInteractions
+        this.selected = selected
+        this.role = role
+        this.onLongClickLabel = onLongClickLabel
+        this.onClickLabel = onClickLabel
+        if (isAttached) updatePlatformConfiguration()
+    }
 
     override fun onAttach() {
         updatePlatformConfiguration()
@@ -536,7 +571,7 @@ private class HardwareEnterKeyEventNode(
                 !observePlatformInteractions ||
                 currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
-        if (previouslyRequiredHardwareInput && !hardwareInputRequired && pressed) {
+        if (previouslyRequiredHardwareInput && !hardwareInputRequired && activePress != null) {
             resetDoubleClick()
             releasePressInteraction()
         }
@@ -593,7 +628,7 @@ private class HardwareEnterKeyEventNode(
                 }
 
                 KeyEventType.KeyUp -> {
-                    if (!isLongClick && pressed) {
+                    if (!isLongClick && activePress != null) {
                         releasePressInteraction()
                         if (onDoubleClick != null) {
                             handleAsDoubleClick()
@@ -601,7 +636,7 @@ private class HardwareEnterKeyEventNode(
                             onClick?.invoke()
                         }
                     } else {
-                        pressed = false
+                        activePress = null
                         isLongClick = false
                     }
                 }
@@ -618,7 +653,7 @@ private class HardwareEnterKeyEventNode(
         if (this.focusState != focusState) {
             this.focusState = focusState
 
-            if (!focusState.isFocused && pressed) {
+            if (!focusState.isFocused && activePress != null) {
                 resetDoubleClick()
                 releasePressInteraction()
             }
@@ -634,16 +669,29 @@ private class HardwareEnterKeyEventNode(
     }
 
     private fun emitPressInteraction() {
+        if (activePress != null) return
+
+        val press = ActivePress(PressInteraction.Press(Offset.Zero), interactionSource)
+        activePress = press
         coroutineScope.launch {
-            interactionSource?.emit(pressInteraction)
-            pressed = true
+            press.interactionSource?.emit(press.interaction)
         }
     }
 
     private fun releasePressInteraction() {
+        val press = activePress ?: return
+        activePress = null
         coroutineScope.launch {
-            interactionSource?.emit(PressInteraction.Release(pressInteraction))
-            pressed = false
+            press.interactionSource?.emit(PressInteraction.Release(press.interaction))
+        }
+    }
+
+    private fun cancelPressInteraction() {
+        val press = activePress ?: return
+        activePress = null
+        isLongClick = false
+        coroutineScope.launch {
+            press.interactionSource?.emit(PressInteraction.Cancel(press.interaction))
         }
     }
 
@@ -696,7 +744,7 @@ private class HardwareEnterKeyEventNode(
 
     private fun reset() {
         resetDoubleClick()
-        pressed = false
+        activePress = null
         isLongClick = false
     }
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.selection.selectable
@@ -17,8 +17,6 @@ import androidx.compose.ui.focus.FocusEventModifierNode
 import androidx.compose.ui.focus.FocusProperties
 import androidx.compose.ui.focus.FocusPropertiesModifierNode
 import androidx.compose.ui.focus.FocusState
-import androidx.compose.ui.focus.FocusTargetModifierNode
-import androidx.compose.ui.focus.Focusability
 import androidx.compose.ui.focus.invalidateFocusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
@@ -27,7 +25,6 @@ import androidx.compose.ui.input.key.KeyInputModifierNode
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
-import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.SemanticsModifierNode
@@ -39,10 +36,8 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.disabled
-import androidx.compose.ui.semantics.focused
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.onLongClick
-import androidx.compose.ui.semantics.requestFocus
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import kotlinx.coroutines.Job
@@ -321,7 +316,8 @@ private fun Modifier.handleTvInputIfRequired(
     onDoubleClick: (() -> Unit)? = null,
     onClickLabel: String? = null,
     onClick: (() -> Unit),
-) = this then PlatformFocusableElement(enabled, interactionSource) then
+) = this then PlatformFocusabilityElement(enabled) then
+    Modifier.focusable(enabled = true, interactionSource = interactionSource) then
     HardwareEnterKeyElement(
         enabled = enabled,
         interactionSource = interactionSource,
@@ -335,114 +331,56 @@ private fun Modifier.handleTvInputIfRequired(
         onClickLabel = onClickLabel,
     )
 
-private data class PlatformFocusableElement(
+private data class PlatformFocusabilityElement(
     val enabled: Boolean,
-    val interactionSource: MutableInteractionSource?,
-) : ModifierNodeElement<PlatformFocusableNode>() {
-    override fun create(): PlatformFocusableNode = PlatformFocusableNode(enabled, interactionSource)
+) : ModifierNodeElement<PlatformFocusabilityNode>() {
+    override fun create(): PlatformFocusabilityNode = PlatformFocusabilityNode(enabled)
 
-    override fun update(node: PlatformFocusableNode) {
-        node.update(enabled, interactionSource)
+    override fun update(node: PlatformFocusabilityNode) {
+        node.update(enabled)
     }
 
     override fun InspectorInfo.inspectableProperties() {
-        name = "platformFocusable"
+        name = "platformFocusability"
         properties["enabled"] = enabled
-        properties["interactionSource"] = interactionSource
     }
 }
 
 @OptIn(ExperimentalWildApi::class)
-private class PlatformFocusableNode(
+private class PlatformFocusabilityNode(
     private var enabled: Boolean,
-    private var interactionSource: MutableInteractionSource?,
-) : DelegatingNode(),
+) : Modifier.Node(),
     CompositionLocalConsumerModifierNode,
     ObserverModifierNode,
-    SemanticsModifierNode {
-    private val focusTarget =
-        delegate(
-            FocusTargetModifierNode(
-                focusability = Focusability.Never,
-                onFocusChange = ::onFocusChange,
-            ),
-        )
-    private var focusInteraction: FocusInteraction.Focus? = null
+    FocusPropertiesModifierNode {
     private var focusEnabled = false
 
     override fun onAttach() {
-        updateFocusability()
+        updateFocusProperties()
     }
 
     override fun onObservedReadsChanged() {
-        updateFocusability()
+        updateFocusProperties()
     }
 
-    fun update(
-        enabled: Boolean,
-        interactionSource: MutableInteractionSource?,
-    ) {
-        if (this.interactionSource !== interactionSource) {
-            disposeFocusInteraction()
-            this.interactionSource = interactionSource
-            if (focusTarget.focusState.isFocused) emitFocusInteraction()
-        }
+    fun update(enabled: Boolean) {
         if (this.enabled != enabled) {
             this.enabled = enabled
-            if (isAttached) updateFocusability()
+            if (isAttached) updateFocusProperties()
         }
     }
 
-    override fun SemanticsPropertyReceiver.applySemantics() {
-        if (focusEnabled) {
-            focused = focusTarget.focusState.isFocused
-            requestFocus { focusTarget.requestFocus() }
-        }
+    override fun applyFocusProperties(focusProperties: FocusProperties) {
+        focusProperties.canFocus = focusEnabled
     }
 
-    override fun onDetach() {
-        disposeFocusInteraction()
-    }
-
-    private fun updateFocusability() {
+    private fun updateFocusProperties() {
         var requiresHardwareInput = false
         observeReads {
             requiresHardwareInput = currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
         focusEnabled = enabled || requiresHardwareInput
-        focusTarget.focusability =
-            if (focusEnabled) {
-                Focusability.Always
-            } else {
-                Focusability.Never
-            }
-        invalidateSemantics()
-    }
-
-    private fun onFocusChange(
-        previous: FocusState,
-        current: FocusState,
-    ) {
-        if (previous.isFocused == current.isFocused) return
-        if (current.isFocused) {
-            emitFocusInteraction()
-        } else {
-            disposeFocusInteraction()
-        }
-        invalidateSemantics()
-    }
-
-    private fun emitFocusInteraction() {
-        val interaction = FocusInteraction.Focus()
-        focusInteraction = interaction
-        coroutineScope.launch { interactionSource?.emit(interaction) }
-    }
-
-    private fun disposeFocusInteraction() {
-        focusInteraction?.let { interaction ->
-            interactionSource?.tryEmit(FocusInteraction.Unfocus(interaction))
-        }
-        focusInteraction = null
+        invalidateFocusProperties()
     }
 }
 

--- a/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
+++ b/foundations/src/commonMain/kotlin/io/daio/wild/foundation/Clickable.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.input.key.KeyInputModifierNode
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.SemanticsModifierNode
@@ -316,8 +317,7 @@ private fun Modifier.handleTvInputIfRequired(
     onDoubleClick: (() -> Unit)? = null,
     onClickLabel: String? = null,
     onClick: (() -> Unit),
-) = this then PlatformFocusabilityElement(enabled) then
-    Modifier.focusable(enabled = true, interactionSource = interactionSource) then
+) = this then PlatformFocusableElement(enabled, interactionSource) then
     HardwareEnterKeyElement(
         enabled = enabled,
         interactionSource = interactionSource,
@@ -331,57 +331,85 @@ private fun Modifier.handleTvInputIfRequired(
         onClickLabel = onClickLabel,
     )
 
-private data class PlatformFocusabilityElement(
+private data class PlatformFocusableElement(
     val enabled: Boolean,
-) : ModifierNodeElement<PlatformFocusabilityNode>() {
-    override fun create(): PlatformFocusabilityNode = PlatformFocusabilityNode(enabled)
+    val interactionSource: MutableInteractionSource?,
+) : ModifierNodeElement<PlatformFocusableNode>() {
+    override fun create(): PlatformFocusableNode = PlatformFocusableNode(enabled, interactionSource)
 
-    override fun update(node: PlatformFocusabilityNode) {
-        node.update(enabled)
+    override fun update(node: PlatformFocusableNode) {
+        node.update(enabled, interactionSource)
     }
 
     override fun InspectorInfo.inspectableProperties() {
-        name = "platformFocusability"
+        name = "platformFocusable"
         properties["enabled"] = enabled
+        properties["interactionSource"] = interactionSource
     }
 }
 
 @OptIn(ExperimentalWildApi::class)
-private class PlatformFocusabilityNode(
+private class PlatformFocusableNode(
     private var enabled: Boolean,
-) : Modifier.Node(),
+    private var interactionSource: MutableInteractionSource?,
+) : DelegatingNode(),
     CompositionLocalConsumerModifierNode,
-    ObserverModifierNode,
-    FocusPropertiesModifierNode {
-    private var focusEnabled = false
+    ObserverModifierNode {
+    private var focusableElement = focusableNodeElement(interactionSource)
+    private val focusableNode = focusableElement.create()
+    private var focusableNodeDelegated = false
 
     override fun onAttach() {
-        updateFocusProperties()
+        updateFocusableDelegation()
     }
 
     override fun onObservedReadsChanged() {
-        updateFocusProperties()
+        updateFocusableDelegation()
     }
 
-    fun update(enabled: Boolean) {
+    fun update(
+        enabled: Boolean,
+        interactionSource: MutableInteractionSource?,
+    ) {
+        if (this.interactionSource !== interactionSource) {
+            this.interactionSource = interactionSource
+            focusableElement = focusableNodeElement(interactionSource)
+            focusableElement.update(focusableNode)
+        }
         if (this.enabled != enabled) {
             this.enabled = enabled
-            if (isAttached) updateFocusProperties()
+            if (isAttached) updateFocusableDelegation()
         }
     }
 
-    override fun applyFocusProperties(focusProperties: FocusProperties) {
-        focusProperties.canFocus = focusEnabled
-    }
-
-    private fun updateFocusProperties() {
+    private fun updateFocusableDelegation() {
         var requiresHardwareInput = false
         observeReads {
             requiresHardwareInput = currentValueOf(LocalPlatformInteractions).requiresHardwareInput
         }
-        focusEnabled = enabled || requiresHardwareInput
-        invalidateFocusProperties()
+        val shouldDelegate = enabled || requiresHardwareInput
+        if (shouldDelegate && !focusableNodeDelegated) {
+            delegate(focusableNode)
+            focusableNodeDelegated = true
+        } else if (!shouldDelegate && focusableNodeDelegated) {
+            undelegate(focusableNode)
+            focusableNodeDelegated = false
+        }
     }
+}
+
+// Compose 1.11.1 exposes focusable as one ordinary node element. Retain that complete node so its
+// pinning, focused-bounds, semantics, and interaction lifecycle can be conditionally delegated.
+@Suppress("UNCHECKED_CAST")
+private fun focusableNodeElement(interactionSource: MutableInteractionSource?): ModifierNodeElement<Modifier.Node> {
+    val element =
+        Modifier.focusable(enabled = true, interactionSource = interactionSource)
+            .foldIn<Modifier.Element?>(null) { previous, current ->
+                check(previous == null) { "Expected Modifier.focusable to contain one element" }
+                current
+            }
+    check(element is ModifierNodeElement<*>) { "Expected Modifier.focusable to use a modifier node" }
+    return element as ModifierNodeElement<Modifier.Node>
 }
 
 /**

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.foundation
 
+import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -97,6 +101,91 @@ class ClickableFastPathTest {
 
             onNodeWithTag(TARGET_TAG).assertIsFocused().performClick()
             runOnIdle { assertEquals(1, clicks) }
+        }
+
+    @Test
+    fun focusedLazyItemRemainsPinnedWhenScrolledOutOfView() =
+        runComposeUiTest {
+            var scrollToItem by mutableStateOf(0)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    val state = rememberLazyListState()
+                    LazyColumn(
+                        modifier = Modifier.size(width = 100.dp, height = 30.dp),
+                        state = state,
+                    ) {
+                        items(30) { index ->
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(width = 100.dp, height = 10.dp)
+                                        .clickable(
+                                            interactionSource = MutableInteractionSource(),
+                                            onClick = {},
+                                        ).testTag("item-$index"),
+                            )
+                        }
+                    }
+                    LaunchedEffect(scrollToItem) {
+                        if (scrollToItem > 0) state.scrollToItem(scrollToItem)
+                    }
+                }
+            }
+
+            onNodeWithTag("item-0")
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+                .assertIsFocused()
+            runOnIdle { scrollToItem = 20 }
+            waitForIdle()
+
+            onNodeWithTag("item-0").assertIsFocused()
+        }
+
+    @Test
+    fun replacingSourceWhileFocusedBalancesOnlyTheOldSource() =
+        runComposeUiTest {
+            val firstSource = MutableInteractionSource()
+            val secondSource = MutableInteractionSource()
+            val firstInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val secondInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var source by mutableStateOf(firstSource)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(interactionSource = source, onClick = {})
+                                .testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(firstSource) {
+                        firstSource.interactions.collect { firstInteractions += it }
+                    }
+                    LaunchedEffect(secondSource) {
+                        secondSource.interactions.collect { secondInteractions += it }
+                    }
+                }
+            }
+
+            waitUntil { firstInteractions.any { it is FocusInteraction.Focus } }
+            runOnIdle { source = secondSource }
+            waitForIdle()
+
+            runOnIdle {
+                val focus = firstInteractions.filterIsInstance<FocusInteraction.Focus>().single()
+                val unfocus = firstInteractions.filterIsInstance<FocusInteraction.Unfocus>().single()
+                assertSame(focus, unfocus.focus)
+                assertTrue(secondInteractions.none { it is FocusInteraction })
+            }
         }
 
     @Test

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -1,0 +1,286 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.foundation
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class, ExperimentalWildApi::class)
+class ClickableFastPathTest {
+    @Test
+    fun nonNullInteractionSourcesUseOrdinaryModifierChains() {
+        val source = MutableInteractionSource()
+
+        val modifiers =
+            listOf(
+                Modifier.clickable(interactionSource = source, onClick = {}),
+                Modifier.selectable(selected = true, interactionSource = source, onClick = {}),
+                Modifier.interactable(interactionSource = source, onClick = {}),
+                Modifier.interactable(selected = true, interactionSource = source, onClick = {}),
+                Modifier.clickable(interactionSource = null, onClick = {}),
+            )
+
+        modifiers.forEach { modifier ->
+            assertFalse(modifier.hasComposedElement(), "Unexpected composed element in $modifier")
+        }
+    }
+
+    @Test
+    fun receiverStaysFirstInTheFastPathChain() {
+        val source = MutableInteractionSource()
+        val modifier =
+            (Modifier then ReceiverMarker).clickable(
+                interactionSource = source,
+                onClick = {},
+            )
+
+        val elements = modifier.elements()
+
+        assertTrue(elements.size > 1)
+        assertSame(ReceiverMarker, elements.first())
+    }
+
+    @Test
+    fun nonHardwareClickableRemainsFocusableAndClickable() =
+        runComposeUiTest {
+            var clicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = false),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            onNodeWithTag(TARGET_TAG).assertIsFocused().performClick()
+            runOnIdle { assertEquals(1, clicks) }
+        }
+
+    @Test
+    fun hardwareEnterAndLongClickSemanticsInvokeCallbacks() =
+        runComposeUiTest {
+            var clicks = 0
+            var longClicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onLongClick = { longClicks++ },
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitForIdle()
+            target.performKeyInput { keyUp(Key.Enter) }
+            runOnIdle { assertEquals(1, clicks) }
+
+            target.performSemanticsAction(SemanticsActions.OnLongClick)
+            runOnIdle { assertEquals(1, longClicks) }
+        }
+
+    @Test
+    fun hardwareDoubleEnterInvokesDoubleClick() =
+        runComposeUiTest {
+            var clicks = 0
+            var doubleClicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onDoubleClick = { doubleClicks++ },
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            repeat(2) {
+                target.performKeyInput { keyDown(Key.Enter) }
+                waitForIdle()
+                target.performKeyInput { keyUp(Key.Enter) }
+                waitForIdle()
+            }
+
+            runOnIdle {
+                assertEquals(0, clicks)
+                assertEquals(1, doubleClicks)
+            }
+        }
+
+    @Test
+    fun disabledHardwareSelectableRemainsFocusedSelectedAndDoesNotHandleEnter() =
+        runComposeUiTest {
+            var clicks = 0
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .selectable(
+                                    selected = true,
+                                    enabled = false,
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.assertIsFocused().assertIsSelected().assertIsNotEnabled()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitForIdle()
+            target.performKeyInput { keyUp(Key.Enter) }
+            runOnIdle { assertEquals(0, clicks) }
+        }
+
+    @Test
+    fun hardwareSemanticsMergeDescendants() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = {},
+                                ).testTag(TARGET_TAG),
+                    ) {
+                        Box(modifier = Modifier.semantics { contentDescription = "Child" })
+                    }
+                }
+            }
+
+            onNodeWithTag(TARGET_TAG).assertContentDescriptionEquals("Child")
+        }
+
+    @Test
+    fun leavingHardwareModeReleasesAnActivePress() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var hardwareInput by mutableStateOf(true)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides
+                        PlatformInteractions(requiresHardwareInput = hardwareInput),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(interactionSource = source, onClick = {})
+                                .testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(source) {
+                        source.interactions.collect { interactions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitForIdle()
+            runOnIdle { hardwareInput = false }
+            waitForIdle()
+
+            runOnIdle {
+                assertTrue(interactions.filterIsInstance<PressInteraction>().last() is PressInteraction.Release)
+            }
+        }
+}
+
+private const val TARGET_TAG = "target"
+
+private data object ReceiverMarker : Modifier.Element
+
+private fun Modifier.hasComposedElement(): Boolean =
+    elements().any { element -> element::class.simpleName?.contains("ComposedModifier") == true }
+
+private fun Modifier.elements(): List<Modifier.Element> =
+    buildList {
+        foldIn(Unit) { _, element -> add(element) }
+    }

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -253,6 +253,113 @@ class ClickableFastPathTest {
         }
 
     @Test
+    fun replacingSourceDuringHardwarePressCancelsTheOldSourceWithoutClicking() =
+        runComposeUiTest {
+            val firstSource = MutableInteractionSource()
+            val secondSource = MutableInteractionSource()
+            val firstInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val secondInteractions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var source by mutableStateOf(firstSource)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = source,
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(firstSource) {
+                        firstSource.interactions.collect { firstInteractions += it }
+                    }
+                    LaunchedEffect(secondSource) {
+                        secondSource.interactions.collect { secondInteractions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitUntil { firstInteractions.any { it is PressInteraction.Press } }
+
+            runOnIdle { source = secondSource }
+            waitForIdle()
+
+            runOnIdle {
+                val press = firstInteractions.filterIsInstance<PressInteraction.Press>().single()
+                val cancel = firstInteractions.filterIsInstance<PressInteraction.Cancel>().single()
+                assertSame(press, cancel.press)
+            }
+
+            target.performKeyInput { keyUp(Key.Enter) }
+            waitForIdle()
+
+            runOnIdle {
+                assertEquals(0, clicks)
+                assertTrue(secondInteractions.none { it is PressInteraction })
+            }
+        }
+
+    @Test
+    fun disablingDuringHardwarePressCancelsThePressWithoutClicking() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var enabled by mutableStateOf(true)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    enabled = enabled,
+                                    interactionSource = source,
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                    LaunchedEffect(source) {
+                        source.interactions.collect { interactions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitUntil { interactions.any { it is PressInteraction.Press } }
+
+            runOnIdle { enabled = false }
+            waitForIdle()
+
+            runOnIdle {
+                val press = interactions.filterIsInstance<PressInteraction.Press>().single()
+                val cancel = interactions.filterIsInstance<PressInteraction.Cancel>().single()
+                assertSame(press, cancel.press)
+            }
+
+            target.performKeyInput { keyUp(Key.Enter) }
+            waitForIdle()
+
+            runOnIdle { assertEquals(0, clicks) }
+        }
+
+    @Test
     fun hardwareDoubleEnterInvokesDoubleClick() =
         runComposeUiTest {
             var clicks = 0

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -101,6 +102,32 @@ class ClickableFastPathTest {
 
             onNodeWithTag(TARGET_TAG).assertIsFocused().performClick()
             runOnIdle { assertEquals(1, clicks) }
+        }
+
+    @Test
+    fun disabledNonHardwareClickableHasNoFocusSemantics() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = false),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .clickable(
+                                    enabled = false,
+                                    interactionSource = MutableInteractionSource(),
+                                    onClick = {},
+                                ).testTag(TARGET_TAG),
+                    )
+                }
+            }
+
+            val semantics = onNodeWithTag(TARGET_TAG).assertIsNotEnabled().fetchSemanticsNode().config
+
+            assertFalse(semantics.contains(SemanticsProperties.Focused))
+            assertFalse(semantics.contains(SemanticsActions.RequestFocus))
         }
 
     @Test

--- a/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/commonTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.foundation
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -19,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -357,6 +359,122 @@ class ClickableFastPathTest {
             waitForIdle()
 
             runOnIdle { assertEquals(0, clicks) }
+        }
+
+    @Test
+    fun removingNodeDuringHardwarePressCancelsTheCapturedSourceWithoutClicking() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var showTarget by mutableStateOf(true)
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    if (showTarget) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(10.dp)
+                                    .focusRequester(requester)
+                                    .clickable(
+                                        interactionSource = source,
+                                        onClick = { clicks++ },
+                                    ).testTag(TARGET_TAG),
+                        )
+                        LaunchedEffect(requester) { requester.requestFocus() }
+                    }
+                    LaunchedEffect(source) {
+                        source.interactions.collect { interactions += it }
+                    }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput { keyDown(Key.Enter) }
+            waitUntil { interactions.any { it is PressInteraction.Press } }
+
+            runOnIdle { showTarget = false }
+            waitForIdle()
+
+            runOnIdle {
+                val press = interactions.filterIsInstance<PressInteraction.Press>().single()
+                val cancel = interactions.filterIsInstance<PressInteraction.Cancel>().single()
+                assertSame(press, cancel.press)
+                assertEquals(0, clicks)
+            }
+        }
+
+    @Test
+    fun longClickDisablingThenReenablingDoesNotCorruptTheNextHardwarePress() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val interactions = mutableListOf<androidx.compose.foundation.interaction.Interaction>()
+            val requester = FocusRequester()
+            var clicks = 0
+            var longClicks = 0
+            var enabled by mutableStateOf(true)
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(10.dp)
+                            .focusRequester(requester)
+                            .focusable(interactionSource = source)
+                            .handleHardwareInputEnter(
+                                enabled = enabled,
+                                interactionSource = source,
+                                onLongClick = {
+                                    longClicks++
+                                    enabled = false
+                                },
+                                onClick = { clicks++ },
+                                eventRepeatCount = { event ->
+                                    if (event.key == Key.NumPadEnter) 1 else 0
+                                },
+                            ).testTag(TARGET_TAG),
+                )
+                LaunchedEffect(requester) { requester.requestFocus() }
+                LaunchedEffect(source) {
+                    source.interactions.collect { interactions += it }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG).assertIsFocused()
+            target.performKeyInput {
+                keyDown(Key.Enter)
+                keyDown(Key.NumPadEnter)
+            }
+            waitUntil { longClicks == 1 }
+            waitForIdle()
+
+            target.performKeyInput {
+                keyUp(Key.NumPadEnter)
+                keyUp(Key.Enter)
+            }
+            runOnIdle { enabled = true }
+            waitForIdle()
+
+            target.performKeyInput {
+                keyDown(Key.Enter)
+                keyUp(Key.Enter)
+            }
+            waitForIdle()
+
+            runOnIdle {
+                val presses = interactions.filterIsInstance<PressInteraction.Press>()
+                val releases = interactions.filterIsInstance<PressInteraction.Release>()
+                assertEquals(2, presses.size)
+                assertEquals(2, releases.size)
+                assertSame(presses[0], releases[0].press)
+                assertSame(presses[1], releases[1].press)
+                assertEquals(1, longClicks)
+                assertEquals(1, clicks)
+            }
         }
 
     @Test

--- a/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -474,6 +475,111 @@ class ClickableFastPathTest {
                 assertEquals(2, releases.size)
                 assertSame(presses[0], releases[0].press)
                 assertSame(presses[1], releases[1].press)
+                assertEquals(1, longClicks)
+                assertEquals(1, clicks)
+            }
+        }
+
+    @Test
+    fun leavingHardwareModeCancelsPendingDoubleClick() =
+        runComposeUiTest {
+            var clicks = 0
+            var doubleClicks = 0
+            var requiresHardwareInput by mutableStateOf(true)
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides
+                        PlatformInteractions(requiresHardwareInput = requiresHardwareInput),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .clickable(
+                                    interactionSource = MutableInteractionSource(),
+                                    onDoubleClick = { doubleClicks++ },
+                                    onClick = { clicks++ },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.performKeyInput {
+                keyDown(Key.Enter)
+                keyUp(Key.Enter)
+            }
+            runOnIdle { requiresHardwareInput = false }
+            waitForIdle()
+            runOnIdle { requiresHardwareInput = true }
+            waitForIdle()
+            delay(400)
+            runOnIdle {
+                assertEquals(0, clicks)
+                assertEquals(0, doubleClicks)
+            }
+        }
+
+    @Test
+    fun leavingHardwareModeClearsCompletedLongClickState() =
+        runComposeUiTest {
+            var clicks = 0
+            var longClicks = 0
+            var requiresHardwareInput by mutableStateOf(true)
+            val requester = FocusRequester()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides
+                        PlatformInteractions(requiresHardwareInput = requiresHardwareInput),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .focusable()
+                                .handleHardwareInputEnter(
+                                    enabled = true,
+                                    interactionSource = MutableInteractionSource(),
+                                    onLongClick = { longClicks++ },
+                                    onClick = { clicks++ },
+                                    eventRepeatCount = { event ->
+                                        if (event.key == Key.NumPadEnter) 1 else 0
+                                    },
+                                ).testTag(TARGET_TAG),
+                    )
+                    LaunchedEffect(requester) { requester.requestFocus() }
+                }
+            }
+
+            val target = onNodeWithTag(TARGET_TAG)
+            target.performKeyInput { keyDown(Key.Enter) }
+            target.performKeyInput { keyDown(Key.NumPadEnter) }
+            waitForIdle()
+            target.performKeyInput {
+                keyUp(Key.NumPadEnter)
+                keyUp(Key.Enter)
+            }
+            runOnIdle { assertEquals(1, longClicks) }
+
+            runOnIdle { requiresHardwareInput = false }
+            waitForIdle()
+            runOnIdle {
+                requiresHardwareInput = true
+                requester.requestFocus()
+            }
+            waitForIdle()
+
+            target.performKeyInput {
+                keyDown(Key.Enter)
+                keyUp(Key.Enter)
+            }
+            runOnIdle {
                 assertEquals(1, longClicks)
                 assertEquals(1, clicks)
             }

--- a/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
@@ -32,6 +33,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -80,6 +82,34 @@ class ClickableFastPathTest {
         assertTrue(elements.size > 1)
         assertSame(ReceiverMarker, elements.first())
     }
+
+    @Test
+    fun callerFocusPropertiesDisableBothHardwareFocusTargets() =
+        runComposeUiTest {
+            val requester = FocusRequester()
+            val source = MutableInteractionSource()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalPlatformInteractions provides PlatformInteractions(requiresHardwareInput = true),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(10.dp)
+                                .focusRequester(requester)
+                                .focusProperties { canFocus = false }
+                                .clickable(
+                                    interactionSource = source,
+                                    onClick = {},
+                                ).testTag(TARGET_TAG),
+                    )
+                }
+            }
+
+            runOnIdle { assertFalse(requester.requestFocus()) }
+            onNodeWithTag(TARGET_TAG).assertIsNotFocused()
+        }
 
     @Test
     fun nonHardwareClickableRemainsFocusableAndClickable() =
@@ -487,6 +517,7 @@ class ClickableFastPathTest {
             var doubleClicks = 0
             var requiresHardwareInput by mutableStateOf(true)
             val requester = FocusRequester()
+            val source = MutableInteractionSource()
 
             setContent {
                 CompositionLocalProvider(
@@ -499,7 +530,7 @@ class ClickableFastPathTest {
                                 .size(10.dp)
                                 .focusRequester(requester)
                                 .clickable(
-                                    interactionSource = MutableInteractionSource(),
+                                    interactionSource = source,
                                     onDoubleClick = { doubleClicks++ },
                                     onClick = { clicks++ },
                                 ).testTag(TARGET_TAG),
@@ -531,6 +562,7 @@ class ClickableFastPathTest {
             var longClicks = 0
             var requiresHardwareInput by mutableStateOf(true)
             val requester = FocusRequester()
+            val source = MutableInteractionSource()
 
             setContent {
                 CompositionLocalProvider(
@@ -545,9 +577,10 @@ class ClickableFastPathTest {
                                 .focusable()
                                 .handleHardwareInputEnter(
                                     enabled = true,
-                                    interactionSource = MutableInteractionSource(),
+                                    interactionSource = source,
                                     onLongClick = { longClicks++ },
                                     onClick = { clicks++ },
+                                    observePlatformInteractions = true,
                                     eventRepeatCount = { event ->
                                         if (event.key == Key.NumPadEnter) 1 else 0
                                     },
@@ -561,14 +594,14 @@ class ClickableFastPathTest {
             target.performKeyInput { keyDown(Key.Enter) }
             target.performKeyInput { keyDown(Key.NumPadEnter) }
             waitForIdle()
+            runOnIdle { requiresHardwareInput = false }
+            waitForIdle()
             target.performKeyInput {
                 keyUp(Key.NumPadEnter)
                 keyUp(Key.Enter)
             }
             runOnIdle { assertEquals(1, longClicks) }
 
-            runOnIdle { requiresHardwareInput = false }
-            waitForIdle()
             runOnIdle {
                 requiresHardwareInput = true
                 requester.requestFocus()

--- a/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
+++ b/foundations/src/jvmTest/kotlin/io/daio/wild/foundation/ClickableFastPathTest.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.foundation
 
+// Desktop-only: runComposeUiTest requires a platform host and Android local unit tests do not provide one.
+
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Clickable.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Clickable.kt
@@ -7,9 +7,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.semantics.Role
-import io.daio.wild.foundation.clickable
-import io.daio.wild.foundation.selectable
 import io.daio.wild.modifier.thenIfNotNull
+import io.daio.wild.foundation.clickable as foundationClickable
+import io.daio.wild.foundation.selectable as foundationSelectable
 
 /**
  * Interop Modifier to support either [Modifier.selectable] or [Modifier.clickable], applying
@@ -207,24 +207,17 @@ fun Modifier.clickable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.clickable(
-        enabled = enabled,
-        interactionSource = interactionSource,
-        role = role,
-        onClick = onClick,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-    ).thenIfNotNull(
-        style,
-        ifNotNullModifier = {
-            Modifier.interactionStyle(interactionSource, enabled, style = it)
-        },
-    )
-}
+): Modifier =
+    if (interactionSource != null) {
+        clickableWithStyle(enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            clickableWithStyle(enabled, rememberedInteractionSource, style, role, onLongClick, onDoubleClick, onClick)
+        }
+    }
 
 /**
  * Interop Modifier.clickable to apply the correct clickable modifier based on the requirement for
@@ -256,24 +249,25 @@ fun Modifier.experimentalClickable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.clickable(
-        enabled = enabled,
-        interactionSource = interactionSource,
-        role = role,
-        onClick = onClick,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-    ).thenIfNotNull(
-        style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(interactionSource, enabled, style = it)
-        },
-    )
-}
+): Modifier =
+    if (interactionSource != null) {
+        experimentalClickableWithStyle(enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalClickableWithStyle(
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
+            )
+        }
+    }
 
 /**
  * Interop Modifier.clickable to apply the correct clickable modifier based on the requirement for
@@ -304,24 +298,25 @@ fun Modifier.experimentalClickable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.clickable(
-        enabled = enabled,
-        interactionSource = interactionSource,
-        role = role,
-        onClick = onClick,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-    ).thenIfNotNull(
-        style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(interactionSource, enabled, block = it)
-        },
-    )
-}
+): Modifier =
+    if (interactionSource != null) {
+        experimentalClickableWithStyle(enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalClickableWithStyle(
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
+            )
+        }
+    }
 
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
@@ -350,30 +345,26 @@ fun Modifier.selectable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.selectable(
-        selected = selected,
-        enabled = enabled,
-        interactionSource = interactionSource,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-        role = role,
-        onClick = onClick,
-    ).thenIfNotNull(
-        value = style,
-        ifNotNullModifier = {
-            Modifier.interactionStyle(
-                style = it,
-                interactionSource = interactionSource,
-                enabled = enabled,
-                selected = selected,
+): Modifier =
+    if (interactionSource != null) {
+        selectableWithStyle(selected, enabled, interactionSource, style, role, onLongClick, onDoubleClick, onClick)
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            selectableWithStyle(
+                selected,
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
             )
-        },
-    )
-}
+        }
+    }
 
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
@@ -407,11 +398,107 @@ fun Modifier.experimentalSelectable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+): Modifier =
+    if (interactionSource != null) {
+        experimentalSelectableWithStyle(
+            selected,
+            enabled,
+            interactionSource,
+            style,
+            role,
+            onLongClick,
+            onDoubleClick,
+            onClick,
+        )
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalSelectableWithStyle(
+                selected,
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
+            )
+        }
+    }
 
-    Modifier.selectable(
+private fun Modifier.clickableWithStyle(
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationClickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.interactionStyle(interactionSource, enabled, style = it)
+    })
+
+private fun Modifier.experimentalClickableWithStyle(
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationClickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(interactionSource, enabled, style = it)
+    })
+
+private fun Modifier.experimentalClickableWithStyle(
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: (StyleScope.() -> Unit)?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationClickable(
+        enabled = enabled,
+        interactionSource = interactionSource,
+        role = role,
+        onClick = onClick,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(interactionSource, enabled, block = it)
+    })
+
+private fun Modifier.selectableWithStyle(
+    selected: Boolean,
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationSelectable(
         selected = selected,
         enabled = enabled,
         interactionSource = interactionSource,
@@ -419,18 +506,68 @@ fun Modifier.experimentalSelectable(
         onDoubleClick = onDoubleClick,
         role = role,
         onClick = onClick,
-    ).thenIfNotNull(
-        value = style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(
-                style = it,
-                interactionSource = interactionSource,
-                enabled = enabled,
-                selected = selected,
-            )
-        },
-    )
-}
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.interactionStyle(
+            style = it,
+            interactionSource = interactionSource,
+            enabled = enabled,
+            selected = selected,
+        )
+    })
+
+private fun Modifier.experimentalSelectableWithStyle(
+    selected: Boolean,
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: Style?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationSelectable(
+        selected = selected,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+        role = role,
+        onClick = onClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(
+            style = it,
+            interactionSource = interactionSource,
+            enabled = enabled,
+            selected = selected,
+        )
+    })
+
+private fun Modifier.experimentalSelectableWithStyle(
+    selected: Boolean,
+    enabled: Boolean,
+    interactionSource: MutableInteractionSource,
+    style: (StyleScope.() -> Unit)?,
+    role: Role?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?,
+    onClick: () -> Unit,
+): Modifier =
+    foundationSelectable(
+        selected = selected,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onLongClick = onLongClick,
+        onDoubleClick = onDoubleClick,
+        role = role,
+        onClick = onClick,
+    ).thenIfNotNull(style, ifNotNullModifier = {
+        Modifier.experimentalInteractionStyle(
+            block = it,
+            interactionSource = interactionSource,
+            enabled = enabled,
+            selected = selected,
+        )
+    })
 
 /**
  * Interop Modifier.selectable to apply the correct selectable modifier based on the requirement for
@@ -462,27 +599,32 @@ fun Modifier.experimentalSelectable(
     onLongClick: (() -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onClick: (() -> Unit),
-) = composed {
-    @Suppress("NAME_SHADOWING")
-    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-
-    Modifier.selectable(
-        selected = selected,
-        enabled = enabled,
-        interactionSource = interactionSource,
-        onLongClick = onLongClick,
-        onDoubleClick = onDoubleClick,
-        role = role,
-        onClick = onClick,
-    ).thenIfNotNull(
-        value = style,
-        ifNotNullModifier = {
-            Modifier.experimentalInteractionStyle(
-                block = it,
-                interactionSource = interactionSource,
-                enabled = enabled,
-                selected = selected,
+): Modifier =
+    if (interactionSource != null) {
+        experimentalSelectableWithStyle(
+            selected,
+            enabled,
+            interactionSource,
+            style,
+            role,
+            onLongClick,
+            onDoubleClick,
+            onClick,
+        )
+    } else {
+        // Compatibility path for callers relying on the nullable-source API. Keep one source for
+        // the lifetime of this modifier instance and share it between input and style observation.
+        composed {
+            val rememberedInteractionSource = remember { MutableInteractionSource() }
+            experimentalSelectableWithStyle(
+                selected,
+                enabled,
+                rememberedInteractionSource,
+                style,
+                role,
+                onLongClick,
+                onDoubleClick,
+                onClick,
             )
-        },
-    )
-}
+        }
+    }

--- a/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
+++ b/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
@@ -1,0 +1,153 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+@file:Suppress("DEPRECATION")
+
+package io.daio.wild.style
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.materialize
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import io.daio.wild.style.modifiers.InteractionSourceElement
+import io.daio.wild.style.modifiers.StyleRecorder
+import io.daio.wild.style.modifiers.recordStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ClickableFastPathTest {
+    @Test
+    fun currentAndDeprecatedNonNullSourceOverloadsUseOrdinaryModifierChains() {
+        val source = MutableInteractionSource()
+        val block: StyleScope.() -> Unit = {}
+
+        val modifiers =
+            listOf(
+                Modifier.clickable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.selectable(true, interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.interactable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.interactable(selected = true, interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalClickable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalClickable(interactionSource = source, style = block, onClick = {}),
+                Modifier.experimentalSelectable(true, interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalSelectable(true, interactionSource = source, style = block, onClick = {}),
+                Modifier.experimentalInteractable(interactionSource = source, style = StyleDefaults.None, onClick = {}),
+                Modifier.experimentalInteractable(interactionSource = source, style = block, onClick = {}),
+                Modifier.experimentalInteractable(
+                    selected = true,
+                    interactionSource = source,
+                    style = StyleDefaults.None,
+                    onClick = {},
+                ),
+                Modifier.experimentalInteractable(
+                    selected = true,
+                    interactionSource = source,
+                    style = block,
+                    onClick = {},
+                ),
+            )
+
+        modifiers.forEach { modifier ->
+            assertFalse(modifier.hasComposedElement(), "Unexpected composed element in $modifier")
+            assertSame(source, modifier.interactionSourceElement()?.interactionSource)
+        }
+    }
+
+    @Test
+    fun receiverStaysFirstAndNullStyleAddsNoStyleObserver() {
+        val source = MutableInteractionSource()
+        val modifier =
+            (Modifier then ReceiverMarker).clickable(
+                interactionSource = source,
+                style = null,
+                onClick = {},
+            )
+
+        val elements = modifier.elements()
+
+        assertTrue(elements.size > 1)
+        assertSame(ReceiverMarker, elements.first())
+        assertFalse(modifier.hasComposedElement())
+        assertSame(null, modifier.interactionSourceElement())
+    }
+
+    @Test
+    fun nullSourceRemembersOneSourceAcrossRecomposition() =
+        runComposeUiTest {
+            val capturedSources = mutableListOf<Any?>()
+            var generation by mutableIntStateOf(0)
+
+            setContent {
+                generation
+                val materialized =
+                    currentComposer.materialize(
+                        Modifier.clickable(
+                            interactionSource = null,
+                            style = StyleDefaults.None,
+                            onClick = {},
+                        ),
+                    )
+                SideEffect {
+                    capturedSources += materialized.interactionSourceElement()?.interactionSource
+                }
+                Box(modifier = materialized)
+            }
+
+            runOnIdle { generation++ }
+            runOnIdle {
+                assertEquals(2, capturedSources.size)
+                assertNotNull(capturedSources.first())
+                assertSame(capturedSources.first(), capturedSources.last())
+            }
+        }
+
+    @Test
+    fun injectedSourceDrivesStyleObservation() =
+        runComposeUiTest {
+            val source = MutableInteractionSource()
+            val recorder = StyleRecorder()
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .clickable(
+                                interactionSource = source,
+                                style = StyleDefaults.None,
+                                onClick = {},
+                            ).recordStyle(recorder),
+                )
+            }
+
+            runOnIdle {
+                assertTrue(source.tryEmit(PressInteraction.Press(Offset.Zero)))
+            }
+            runOnIdle { assertTrue(recorder.last.pressed) }
+        }
+}
+
+private data object ReceiverMarker : Modifier.Element
+
+private fun Modifier.hasComposedElement(): Boolean =
+    elements().any { element -> element::class.simpleName?.contains("ComposedModifier") == true }
+
+private fun Modifier.interactionSourceElement(): InteractionSourceElement? =
+    elements().filterIsInstance<InteractionSourceElement>().firstOrNull()
+
+private fun Modifier.elements(): List<Modifier.Element> =
+    buildList {
+        foldIn(Unit) { _, element -> add(element) }
+    }

--- a/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
+++ b/style/src/commonTest/kotlin/io/daio/wild/style/ClickableFastPathTest.kt
@@ -5,18 +5,22 @@
 package io.daio.wild.style
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.materialize
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
 import io.daio.wild.style.modifiers.InteractionSourceElement
 import io.daio.wild.style.modifiers.StyleRecorder
 import io.daio.wild.style.modifiers.recordStyle
@@ -115,7 +119,7 @@ class ClickableFastPathTest {
         }
 
     @Test
-    fun injectedSourceDrivesStyleObservation() =
+    fun focusInputThroughInjectedSourceDrivesStyleObservation() =
         runComposeUiTest {
             val source = MutableInteractionSource()
             val recorder = StyleRecorder()
@@ -124,20 +128,25 @@ class ClickableFastPathTest {
                 Box(
                     modifier =
                         Modifier
+                            .size(10.dp)
                             .clickable(
                                 interactionSource = source,
                                 style = StyleDefaults.None,
                                 onClick = {},
-                            ).recordStyle(recorder),
+                            ).recordStyle(recorder)
+                            .testTag(TARGET_TAG),
                 )
             }
 
-            runOnIdle {
-                assertTrue(source.tryEmit(PressInteraction.Press(Offset.Zero)))
-            }
-            runOnIdle { assertTrue(recorder.last.pressed) }
+            onNodeWithTag(TARGET_TAG)
+                .performSemanticsAction(SemanticsActions.RequestFocus)
+            waitForIdle()
+
+            runOnIdle { assertTrue(recorder.last.focused) }
         }
 }
+
+private const val TARGET_TAG = "target"
 
 private data object ReceiverMarker : Modifier.Element
 


### PR DESCRIPTION
## Summary

This is the first PR in the THE-220 stack.

- remove Wild-owned `composed` from explicit-source foundation/style clickable and selectable fast paths
- preserve the nullable-source compatibility fallback
- retain focus, keyboard, long-click, double-click, source replacement, disable, reset, and detach behavior
- keep desktop Compose UI coverage in the JVM test source set

Linear: https://linear.app/the-good-egg-studio/issue/THE-220/remove-composed-from-styled-clickableselectable-fast-paths

## Validation

- `:foundations:testDebugUnitTest`
- `:foundations:jvmTest`
- `:style:jvmTest`
- focused lifecycle and source-routing coverage passed

The remaining PRs stack on this branch.