### PR TITLE
test: add interaction fast-path benchmarks (THE-220) [3/3]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ dokka = "2.2.0"
 ktlint = "1.0.1"
 kotlin = "2.4.10"
 roborazzi = "1.69.0"
+robolectric = "4.16"
 spotless = "8.8.0"
 tv-foundation = "1.0.0"
 tv-material = "1.1.0"
@@ -41,6 +42,7 @@ ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 compose-rules-detekt = { module = "io.nlopez.compose.rules:detekt", version = "0.6.3" }
 tools-desugarjdklibs = "com.android.tools:desugar_jdk_libs:2.1.5"
 androidx-benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark" }

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -3,10 +3,23 @@
 The TV macrobenchmark suite compares equivalent grid items across explicit style variants:
 
 - `current_traversal`: production Wild `Modifier.clickable(style = ...)` traversable-node chain.
+- `explicit_source_fast_path`: production Wild styled clickable with one remembered, non-null
+  `MutableInteractionSource`, exercising the ordinary modifier path.
+- `null_source_compatibility`: the same styled clickable and item configuration with a null source,
+  exercising the compatibility `composed` path.
 - `candidate_composite`: benchmark-only candidate path that routes the same shared item configuration through `Container` so it can be replaced by a unified-node prototype without changing scenario setup.
 - `material_surface`: Android TV Material `Surface` baseline using matching size, colors, shape, border, scale target, item count, and deterministic focus input.
 
 The benchmark hoists the shared Wild `Style` out of lazy item bodies for the Wild variants. This keeps style construction out of the scroll measurement; add a separate microbenchmark if style construction or node creation cost is the target.
+
+`recomposeUnchangedGridWithExplicitSourceFastPath` and
+`recomposeUnchangedGridWithNullSourceCompatibility` are the directly comparable source-path pair.
+They use the same implementation, text, style, layout, item count, compilation mode, metrics, and
+focus sequence; only the interaction-source strategy differs. After every deterministic focus move,
+the benchmark injects a handled `R` key-up. Every visible item observes the same stable driver's
+snapshot generation, so the items recompose while their parameters and clickable configuration stay
+unchanged. A `SideEffect` acknowledges the generation only after item composition applies; the app
+then exposes `benchmark-recomposition-N` so the macrobenchmark waits for completion before continuing.
 
 ## Reproduction
 
@@ -14,6 +27,15 @@ Run the suite on the same physical Android TV or matching device profile for eve
 
 ```bash
 ./gradlew :internal:benchmark:connectedCheck
+```
+
+To run only the directly comparable unchanged-recomposition cases:
+
+```bash
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class="io.daio.wild.benchmark.TvBenchmarkTest#recomposeUnchangedGridWithExplicitSourceFastPath"
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class="io.daio.wild.benchmark.TvBenchmarkTest#recomposeUnchangedGridWithNullSourceCompatibility"
 ```
 
 Run at least two invocations and compare variance before making performance conclusions:
@@ -26,3 +48,7 @@ Run at least two invocations and compare variance before making performance conc
 The macrobenchmarks use warm startup, 20 measured iterations, `CompilationMode.Partial()`, `FrameTimingMetric`, and `MemoryUsageMetric(Mode.Max)`. Record the device model, Android version, build type, Compose version, compilation mode, iteration count, and item count with exported benchmark results.
 
 Report median and tail frame times, missed or overrun frames, max memory usage, and run-to-run variance. Establish a baseline before adding regression thresholds.
+
+Peak memory supports a relative allocation-pressure comparison but is not an exact allocation count.
+Use the captured traces or Android Studio's memory profiler when object-level allocation attribution is
+required; do not infer exact allocation counts from `MemoryUsageMetric` alone.

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -20,6 +20,10 @@ the benchmark injects a handled `R` key-up. Every visible item observes the same
 snapshot generation, so the items recompose while their parameters and clickable configuration stay
 unchanged. A `SideEffect` acknowledges the generation only after item composition applies; the app
 then exposes `benchmark-recomposition-N` so the macrobenchmark waits for completion before continuing.
+The optional real-wiring test observer leaves one nullable field on the shared driver and one
+lookup/null branch in each driven item. Both measured variants pay that same minimal overhead;
+detailed composition records and their marker strings are created only when the test observer is
+present.
 
 ## Reproduction
 

--- a/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
@@ -22,15 +22,19 @@ private const val DEFAULT_ITERATIONS = 20
 private const val APP_PACKAGE = "io.daio.wild.playbook.tv"
 private const val MODE_EXTRA = "MODE"
 private const val ITEMS_EXTRA = "ITEMS"
+private const val RECOMPOSITION_DRIVER_EXTRA = "RECOMPOSITION_DRIVER"
 private const val GRID_MODE = "grid"
 private const val FIRST_FOCUS_TARGET = "benchmark-item-0-0"
 private const val TERMINAL_FOCUS_TARGET = "benchmark-item-5-20"
+private const val RECOMPOSITION_MARKER_PREFIX = "benchmark-recomposition-"
 private const val FOCUS_TARGET_TIMEOUT_MS = 5_000L
 private const val INPUT_PACE_MS = 80L
 private val BENCHMARK_COMPILATION_MODE = CompilationMode.Partial()
 
 private enum class StyleVariant(val extraValue: String) {
     CurrentTraversal("current_traversal"),
+    ExplicitSourceFastPath("explicit_source_fast_path"),
+    NullSourceCompatibility("null_source_compatibility"),
     CandidateComposite("candidate_composite"),
     MaterialSurface("material_surface"),
 }
@@ -63,9 +67,28 @@ class TvBenchmarkTest {
     fun scrollGridWithMaterialSurface() {
         benchmarkRule.measureStyleVariant(StyleVariant.MaterialSurface)
     }
+
+    @Test
+    fun recomposeUnchangedGridWithExplicitSourceFastPath() {
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.ExplicitSourceFastPath,
+            enableRecompositionDriver = true,
+        )
+    }
+
+    @Test
+    fun recomposeUnchangedGridWithNullSourceCompatibility() {
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.NullSourceCompatibility,
+            enableRecompositionDriver = true,
+        )
+    }
 }
 
-private fun MacrobenchmarkRule.measureStyleVariant(variant: StyleVariant) {
+private fun MacrobenchmarkRule.measureStyleVariant(
+    variant: StyleVariant,
+    enableRecompositionDriver: Boolean = false,
+) {
     measureRepeated(
         packageName = APP_PACKAGE,
         metrics = styleMetrics(),
@@ -76,14 +99,20 @@ private fun MacrobenchmarkRule.measureStyleVariant(variant: StyleVariant) {
             startActivityAndWait {
                 it.putExtra(MODE_EXTRA, GRID_MODE)
                 it.putExtra(ITEMS_EXTRA, variant.extraValue)
+                it.putExtra(RECOMPOSITION_DRIVER_EXTRA, enableRecompositionDriver)
             }
             device.waitForIdle()
             check(device.wait(Until.hasObject(By.desc(FIRST_FOCUS_TARGET)), FOCUS_TARGET_TIMEOUT_MS)) {
                 "Timed out waiting for first benchmark focus target $FIRST_FOCUS_TARGET"
             }
+            if (enableRecompositionDriver) {
+                check(device.wait(Until.hasObject(By.desc(recompositionMarker(0))), FOCUS_TARGET_TIMEOUT_MS)) {
+                    "Timed out waiting for initial recomposition marker ${recompositionMarker(0)}"
+                }
+            }
         },
     ) {
-        device.runDeterministicFocusSequence()
+        device.runDeterministicFocusSequence(enableRecompositionDriver)
     }
 }
 
@@ -94,16 +123,36 @@ private fun styleMetrics(): List<Metric> =
         MemoryUsageMetric(MemoryUsageMetric.Mode.Max),
     )
 
-private fun UiDevice.runDeterministicFocusSequence() {
+private fun UiDevice.runDeterministicFocusSequence(enableRecompositionDriver: Boolean) {
+    var recompositionGeneration = 0
+
     pressKeyCode(KeyEvent.KEYCODE_DPAD_RIGHT)
     waitForIdle()
+    if (enableRecompositionDriver) {
+        requestUnchangedRecomposition(++recompositionGeneration)
+    }
 
     DETERMINISTIC_FOCUS_SEQUENCE.forEach { keyCode ->
         pressKeyCode(keyCode)
         waitForIdle(INPUT_PACE_MS)
+        if (enableRecompositionDriver) {
+            requestUnchangedRecomposition(++recompositionGeneration)
+        }
     }
 
     check(wait(Until.hasObject(By.desc(TERMINAL_FOCUS_TARGET)), FOCUS_TARGET_TIMEOUT_MS)) {
         "Timed out waiting for terminal benchmark focus target $TERMINAL_FOCUS_TARGET"
     }
 }
+
+private fun UiDevice.requestUnchangedRecomposition(generation: Int) {
+    check(pressKeyCode(KeyEvent.KEYCODE_R)) { "Failed to inject recomposition key" }
+    waitForIdle(INPUT_PACE_MS)
+
+    val marker = recompositionMarker(generation)
+    check(wait(Until.hasObject(By.desc(marker)), FOCUS_TARGET_TIMEOUT_MS)) {
+        "Timed out waiting for recomposition marker $marker"
+    }
+}
+
+private fun recompositionMarker(generation: Int): String = "$RECOMPOSITION_MARKER_PREFIX$generation"

--- a/playbook/androidTv/build.gradle.kts
+++ b/playbook/androidTv/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(compose.foundation)
     implementation(projects.layout.container)
     implementation(projects.components.button)
+
+    testImplementation(libs.junit)
 }
 
 android {

--- a/playbook/androidTv/build.gradle.kts
+++ b/playbook/androidTv/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation(projects.components.button)
 
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.ui.test.junit4)
+    debugImplementation(libs.ui.test.manifest)
 }
 
 android {
@@ -23,6 +26,23 @@ android {
         versionName = "1.0.0"
         applicationId = "io.daio.wild.playbook.tv"
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+        unitTests.all {
+            val configuredLocalRepository = System.getProperty("maven.repo.local")
+            val resolvedLocalRepository =
+                configuredLocalRepository
+                    ?.takeUnless { path -> path.isBlank() || "\${user.home}" in path }
+                    ?: "${System.getProperty("user.home")}/.m2/repository"
+            it.systemProperty(
+                "maven.repo.local",
+                resolvedLocalRepository,
+            )
+        }
     }
 
     buildTypes {

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/MainActivity.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/MainActivity.kt
@@ -11,8 +11,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val mode = intent.getStringExtra("MODE") ?: "grid"
         val items = intent.getStringExtra("ITEMS") ?: "container"
+        val enableRecompositionDriver = intent.getBooleanExtra("RECOMPOSITION_DRIVER", false)
         setContent {
-            TvLayout(itemsType = items, mode = mode)
+            TvLayout(
+                itemsType = items,
+                mode = mode,
+                enableRecompositionDriver = enableRecompositionDriver,
+            )
         }
     }
 }

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -88,7 +88,9 @@ internal fun benchmarkStyleVariant(extraValue: String): StyleVariant =
     StyleVariant.entries.firstOrNull { it.extraValue == extraValue } ?: StyleVariant.Container
 
 @Stable
-internal class BenchmarkRecompositionDriver {
+internal class BenchmarkRecompositionDriver(
+    internal val runtimeObserver: BenchmarkItemRuntimeObserver? = null,
+) {
     private val generationState = mutableIntStateOf(0)
     private val appliedGenerationState = mutableIntStateOf(0)
 
@@ -104,6 +106,30 @@ internal class BenchmarkRecompositionDriver {
         if (generation > appliedGenerationState.intValue) {
             appliedGenerationState.intValue = generation
         }
+    }
+}
+
+internal data class BenchmarkItemAppliedComposition(
+    val generation: Int,
+    val receiverModifier: Modifier,
+    val onClick: () -> Unit,
+    val style: Style,
+    val interactionSourceStrategy: BenchmarkInteractionSourceStrategy,
+    val interactionSource: MutableInteractionSource?,
+    val clickableModifier: Modifier,
+    val markerBefore: String,
+    val markerAfter: String,
+)
+
+@Stable
+internal class BenchmarkItemRuntimeObserver {
+    private val mutableAppliedCompositions = mutableListOf<BenchmarkItemAppliedComposition>()
+
+    val appliedCompositions: List<BenchmarkItemAppliedComposition>
+        get() = mutableAppliedCompositions
+
+    internal fun recordApplied(composition: BenchmarkItemAppliedComposition) {
+        mutableAppliedCompositions += composition
     }
 }
 
@@ -197,6 +223,29 @@ private fun BenchmarkLayout(
         "list" -> OptionsList(variant, modifier, recompositionDriver)
         "grid" -> OptionsGrid(variant, modifier, recompositionDriver)
     }
+}
+
+@Composable
+internal fun BenchmarkSourcePathItem(
+    variant: StyleVariant,
+    recompositionDriver: BenchmarkRecompositionDriver,
+    modifier: Modifier = Modifier,
+) {
+    require(variant.implementation == BenchmarkItemImplementation.StyledClickable)
+    val config = remember { BenchmarkItemConfig() }
+    val style = remember(config) { config.style }
+    val onClick = remember { {} }
+
+    BenchmarkItem(
+        variant = variant,
+        title = variant.benchmarkTitle,
+        style = style,
+        config = config,
+        marker = "benchmark-source-path-probe",
+        recompositionDriver = recompositionDriver,
+        onClick = onClick,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -307,26 +356,51 @@ private fun StyledClickableItem(
     recompositionDriver: BenchmarkRecompositionDriver?,
     modifier: Modifier = Modifier,
 ) {
-    if (recompositionDriver != null) {
-        // The stable driver parameter does not change. Reading its snapshot state invalidates this
-        // scope directly while every clickable argument remains unchanged, and SideEffect publishes
-        // completion only after the successful composition has been applied.
-        val recompositionGeneration = recompositionDriver.generation
-        SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
-    }
+    // The stable driver parameter does not change. Reading its snapshot state invalidates this
+    // scope directly while every clickable argument remains unchanged.
+    val recompositionGeneration = recompositionDriver?.generation
 
     val interactionSource =
         when (interactionSourceStrategy) {
             BenchmarkInteractionSourceStrategy.Explicit -> remember { MutableInteractionSource() }
             BenchmarkInteractionSourceStrategy.NullCompatibility -> null
         }
+    val clickableModifier =
+        modifier.clickable(
+            onClick = onClick,
+            interactionSource = interactionSource,
+            style = style,
+        )
+    val runtimeObserver = recompositionDriver?.runtimeObserver
+
+    if (recompositionDriver != null && recompositionGeneration != null) {
+        if (runtimeObserver == null) {
+            SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
+        } else {
+            // Observer-only values stay out of the measured null-observer path. The detailed record
+            // is published after this successful test-probe composition has been applied.
+            SideEffect {
+                val markerBefore = recompositionDriver.marker
+                recompositionDriver.acknowledgeApplied(recompositionGeneration)
+                runtimeObserver.recordApplied(
+                    BenchmarkItemAppliedComposition(
+                        generation = recompositionGeneration,
+                        receiverModifier = modifier,
+                        onClick = onClick,
+                        style = style,
+                        interactionSourceStrategy = interactionSourceStrategy,
+                        interactionSource = interactionSource,
+                        clickableModifier = clickableModifier,
+                        markerBefore = markerBefore,
+                        markerAfter = recompositionDriver.marker,
+                    ),
+                )
+            }
+        }
+    }
+
     Box(
-        modifier =
-            modifier.clickable(
-                onClick = onClick,
-                interactionSource = interactionSource,
-                style = style,
-            ),
+        modifier = clickableModifier,
     ) {
         BenchmarkItemText(title)
     }

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -14,10 +14,18 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -35,12 +43,68 @@ import androidx.tv.material3.LocalContentColor as TvLocalContentColor
 private const val GRID_ROWS = 20
 private const val GRID_COLUMNS = 100
 private const val LIST_ITEMS = 100
+private const val SOURCE_PATH_BENCHMARK_TITLE = "styled_clickable_source_path"
 
-private enum class StyleVariant(val extraValue: String) {
-    CurrentTraversal("current_traversal"),
-    CandidateComposite("candidate_composite"),
-    MaterialSurface("material_surface"),
-    Container("container"),
+internal enum class BenchmarkItemImplementation {
+    StyledClickable,
+    CandidateComposite,
+    MaterialSurface,
+}
+
+internal enum class BenchmarkInteractionSourceStrategy {
+    Explicit,
+    NullCompatibility,
+}
+
+internal enum class StyleVariant(
+    val extraValue: String,
+    val implementation: BenchmarkItemImplementation,
+    val interactionSourceStrategy: BenchmarkInteractionSourceStrategy? = null,
+    val benchmarkTitle: String = extraValue,
+) {
+    CurrentTraversal(
+        "current_traversal",
+        BenchmarkItemImplementation.StyledClickable,
+        BenchmarkInteractionSourceStrategy.Explicit,
+    ),
+    ExplicitSourceFastPath(
+        "explicit_source_fast_path",
+        BenchmarkItemImplementation.StyledClickable,
+        BenchmarkInteractionSourceStrategy.Explicit,
+        SOURCE_PATH_BENCHMARK_TITLE,
+    ),
+    NullSourceCompatibility(
+        "null_source_compatibility",
+        BenchmarkItemImplementation.StyledClickable,
+        BenchmarkInteractionSourceStrategy.NullCompatibility,
+        SOURCE_PATH_BENCHMARK_TITLE,
+    ),
+    CandidateComposite("candidate_composite", BenchmarkItemImplementation.CandidateComposite),
+    MaterialSurface("material_surface", BenchmarkItemImplementation.MaterialSurface),
+    Container("container", BenchmarkItemImplementation.CandidateComposite),
+}
+
+internal fun benchmarkStyleVariant(extraValue: String): StyleVariant =
+    StyleVariant.entries.firstOrNull { it.extraValue == extraValue } ?: StyleVariant.Container
+
+@Stable
+internal class BenchmarkRecompositionDriver {
+    private val generationState = mutableIntStateOf(0)
+    private val appliedGenerationState = mutableIntStateOf(0)
+
+    val generation: Int
+        get() = generationState.intValue
+
+    val marker: String
+        get() = "benchmark-recomposition-${appliedGenerationState.intValue}"
+
+    fun advance(): Int = ++generationState.intValue
+
+    fun acknowledgeApplied(generation: Int) {
+        if (generation > appliedGenerationState.intValue) {
+            appliedGenerationState.intValue = generation
+        }
+    }
 }
 
 private data class BenchmarkItemConfig(
@@ -88,12 +152,50 @@ fun TvLayout(
     modifier: Modifier = Modifier,
     mode: String = "list",
     itemsType: String = StyleVariant.Container.extraValue,
+    enableRecompositionDriver: Boolean = false,
 ) {
-    val variant = StyleVariant.entries.firstOrNull { it.extraValue == itemsType } ?: StyleVariant.Container
+    val variant = benchmarkStyleVariant(itemsType)
 
+    if (enableRecompositionDriver) {
+        RecompositionDrivenLayout(variant, mode, modifier)
+    } else {
+        BenchmarkLayout(variant, mode, modifier)
+    }
+}
+
+@Composable
+private fun RecompositionDrivenLayout(
+    variant: StyleVariant,
+    mode: String,
+    modifier: Modifier,
+) {
+    val driver = remember { BenchmarkRecompositionDriver() }
+    val drivenModifier =
+        modifier
+            .onPreviewKeyEvent { event ->
+                if (event.key != Key.R) {
+                    false
+                } else {
+                    if (event.type == KeyEventType.KeyUp) {
+                        driver.advance()
+                    }
+                    true
+                }
+            }.semantics { contentDescription = driver.marker }
+
+    BenchmarkLayout(variant, mode, drivenModifier, driver)
+}
+
+@Composable
+private fun BenchmarkLayout(
+    variant: StyleVariant,
+    mode: String,
+    modifier: Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
+) {
     when (mode) {
-        "list" -> OptionsList(variant, modifier)
-        "grid" -> OptionsGrid(variant, modifier)
+        "list" -> OptionsList(variant, modifier, recompositionDriver)
+        "grid" -> OptionsGrid(variant, modifier, recompositionDriver)
     }
 }
 
@@ -101,6 +203,7 @@ fun TvLayout(
 private fun OptionsGrid(
     variant: StyleVariant,
     modifier: Modifier = Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
 ) {
     val config = remember { BenchmarkItemConfig() }
     val style = remember(config) { config.style }
@@ -117,10 +220,11 @@ private fun OptionsGrid(
                 items(GRID_COLUMNS, key = { it }) { column ->
                     BenchmarkItem(
                         variant = variant,
-                        title = variant.extraValue,
+                        title = variant.benchmarkTitle,
                         style = style,
                         config = config,
                         marker = "benchmark-item-$row-$column",
+                        recompositionDriver = recompositionDriver,
                         onClick = { },
                     )
                 }
@@ -133,6 +237,7 @@ private fun OptionsGrid(
 private fun OptionsList(
     variant: StyleVariant,
     modifier: Modifier = Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
 ) {
     val config = remember { BenchmarkItemConfig() }
     val style = remember(config) { config.style }
@@ -152,10 +257,11 @@ private fun OptionsList(
         items(LIST_ITEMS, key = { it }) { index ->
             BenchmarkItem(
                 variant = variant,
-                title = variant.extraValue,
+                title = variant.benchmarkTitle,
                 style = style,
                 config = config,
                 marker = "benchmark-item-0-$index",
+                recompositionDriver = recompositionDriver,
                 onClick = { },
             )
         }
@@ -169,27 +275,51 @@ private fun BenchmarkItem(
     style: Style,
     config: BenchmarkItemConfig,
     marker: String,
+    recompositionDriver: BenchmarkRecompositionDriver?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val itemModifier = modifier.benchmarkItemMarker(marker).size(config.itemSize)
 
-    when (variant) {
-        StyleVariant.CurrentTraversal -> CurrentTraversalItem(title, onClick, style, itemModifier)
-        StyleVariant.CandidateComposite -> CandidateCompositeItem(title, onClick, style, itemModifier)
-        StyleVariant.MaterialSurface -> MaterialSurfaceItem(title, onClick, config, itemModifier)
-        StyleVariant.Container -> CandidateCompositeItem(title, onClick, style, itemModifier)
+    when (variant.implementation) {
+        BenchmarkItemImplementation.StyledClickable ->
+            StyledClickableItem(
+                title = title,
+                onClick = onClick,
+                style = style,
+                interactionSourceStrategy = checkNotNull(variant.interactionSourceStrategy),
+                recompositionDriver = recompositionDriver,
+                modifier = itemModifier,
+            )
+        BenchmarkItemImplementation.CandidateComposite ->
+            CandidateCompositeItem(title, onClick, style, itemModifier)
+        BenchmarkItemImplementation.MaterialSurface ->
+            MaterialSurfaceItem(title, onClick, config, itemModifier)
     }
 }
 
 @Composable
-private fun CurrentTraversalItem(
+private fun StyledClickableItem(
     title: String,
     onClick: () -> Unit,
     style: Style,
+    interactionSourceStrategy: BenchmarkInteractionSourceStrategy,
+    recompositionDriver: BenchmarkRecompositionDriver?,
     modifier: Modifier = Modifier,
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
+    if (recompositionDriver != null) {
+        // The stable driver parameter does not change. Reading its snapshot state invalidates this
+        // scope directly while every clickable argument remains unchanged, and SideEffect publishes
+        // completion only after the successful composition has been applied.
+        val recompositionGeneration = recompositionDriver.generation
+        SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
+    }
+
+    val interactionSource =
+        when (interactionSourceStrategy) {
+            BenchmarkInteractionSourceStrategy.Explicit -> remember { MutableInteractionSource() }
+            BenchmarkInteractionSourceStrategy.NullCompatibility -> null
+        }
     Box(
         modifier =
             modifier.clickable(

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -377,8 +377,9 @@ private fun StyledClickableItem(
         if (runtimeObserver == null) {
             SideEffect { recompositionDriver.acknowledgeApplied(recompositionGeneration) }
         } else {
-            // Observer-only values stay out of the measured null-observer path. The detailed record
-            // is published after this successful test-probe composition has been applied.
+            // Both benchmark variants share the nullable-observer lookup and branch. Detailed
+            // records and marker strings are created only by observer-enabled test probes, after
+            // the composition has been applied.
             SideEffect {
                 val markerBefore = recompositionDriver.marker
                 recompositionDriver.acknowledgeApplied(recompositionGeneration)

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -2,11 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.android.tv
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class TvBenchmarkScenarioTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
     @Test
     fun explicitAndNullSourceVariantsRouteThroughDistinctSourceStrategies() {
         val fastPath = benchmarkStyleVariant("explicit_source_fast_path")
@@ -58,4 +71,102 @@ class TvBenchmarkScenarioTest {
 
         assertEquals("benchmark-recomposition-1", driver.marker)
     }
+
+    @Test
+    fun realSourcePathItemsRecomposeWithStableInputsAndDistinctModifierRoutes() {
+        val explicitObserver = BenchmarkItemRuntimeObserver()
+        val compatibilityObserver = BenchmarkItemRuntimeObserver()
+        val explicitDriver = BenchmarkRecompositionDriver(explicitObserver)
+        val compatibilityDriver = BenchmarkRecompositionDriver(compatibilityObserver)
+        val explicitMarkersDuringComposition = mutableListOf<Pair<Int, String>>()
+        val compatibilityMarkersDuringComposition = mutableListOf<Pair<Int, String>>()
+
+        composeRule.setContent {
+            val explicitGeneration = explicitDriver.generation
+            val compatibilityGeneration = compatibilityDriver.generation
+            Box {
+                BenchmarkSourcePathItem(
+                    variant = benchmarkStyleVariant("explicit_source_fast_path"),
+                    recompositionDriver = explicitDriver,
+                )
+                BenchmarkSourcePathItem(
+                    variant = benchmarkStyleVariant("null_source_compatibility"),
+                    recompositionDriver = compatibilityDriver,
+                )
+            }
+            explicitMarkersDuringComposition += explicitGeneration to explicitDriver.marker
+            compatibilityMarkersDuringComposition += compatibilityGeneration to compatibilityDriver.marker
+        }
+
+        composeRule.runOnIdle {
+            assertSourcePathInitialApplication(
+                observer = explicitObserver,
+                expectsComposedModifier = false,
+                expectsExplicitSource = true,
+            )
+            assertSourcePathInitialApplication(
+                observer = compatibilityObserver,
+                expectsComposedModifier = true,
+                expectsExplicitSource = false,
+            )
+
+            explicitDriver.advance()
+            compatibilityDriver.advance()
+        }
+
+        composeRule.runOnIdle {
+            assertSourcePathRecomposition(
+                observer = explicitObserver,
+                driver = explicitDriver,
+                markersDuringComposition = explicitMarkersDuringComposition,
+            )
+            assertSourcePathRecomposition(
+                observer = compatibilityObserver,
+                driver = compatibilityDriver,
+                markersDuringComposition = compatibilityMarkersDuringComposition,
+            )
+        }
+    }
 }
+
+private fun assertSourcePathInitialApplication(
+    observer: BenchmarkItemRuntimeObserver,
+    expectsComposedModifier: Boolean,
+    expectsExplicitSource: Boolean,
+) {
+    assertEquals(1, observer.appliedCompositions.size)
+    assertEquals(
+        expectsComposedModifier,
+        observer.appliedCompositions.single().clickableModifier.hasComposedElement(),
+    )
+    if (expectsExplicitSource) {
+        assertTrue(observer.appliedCompositions.single().interactionSource != null)
+    } else {
+        assertNull(observer.appliedCompositions.single().interactionSource)
+    }
+}
+
+private fun assertSourcePathRecomposition(
+    observer: BenchmarkItemRuntimeObserver,
+    driver: BenchmarkRecompositionDriver,
+    markersDuringComposition: List<Pair<Int, String>>,
+) {
+    assertEquals(listOf(0, 1), observer.appliedCompositions.map { it.generation })
+
+    val initial = observer.appliedCompositions.first()
+    val recomposed = observer.appliedCompositions.last()
+    assertSame(initial.receiverModifier, recomposed.receiverModifier)
+    assertSame(initial.onClick, recomposed.onClick)
+    assertSame(initial.style, recomposed.style)
+    assertSame(initial.interactionSource, recomposed.interactionSource)
+    assertEquals(initial.interactionSourceStrategy, recomposed.interactionSourceStrategy)
+    assertTrue(1 to "benchmark-recomposition-0" in markersDuringComposition)
+    assertEquals("benchmark-recomposition-0", recomposed.markerBefore)
+    assertEquals("benchmark-recomposition-1", recomposed.markerAfter)
+    assertEquals("benchmark-recomposition-1", driver.marker)
+}
+
+private fun Modifier.hasComposedElement(): Boolean =
+    foldIn(false) { found, element ->
+        found || element::class.simpleName?.contains("ComposedModifier") == true
+    }

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -1,0 +1,61 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.android.tv
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TvBenchmarkScenarioTest {
+    @Test
+    fun explicitAndNullSourceVariantsRouteThroughDistinctSourceStrategies() {
+        val fastPath = benchmarkStyleVariant("explicit_source_fast_path")
+        val compatibilityPath = benchmarkStyleVariant("null_source_compatibility")
+
+        assertEquals(BenchmarkItemImplementation.StyledClickable, fastPath.implementation)
+        assertEquals(BenchmarkItemImplementation.StyledClickable, compatibilityPath.implementation)
+        assertEquals(fastPath.benchmarkTitle, compatibilityPath.benchmarkTitle)
+        assertEquals(BenchmarkInteractionSourceStrategy.Explicit, fastPath.interactionSourceStrategy)
+        assertEquals(
+            BenchmarkInteractionSourceStrategy.NullCompatibility,
+            compatibilityPath.interactionSourceStrategy,
+        )
+        assertNotEquals(fastPath.interactionSourceStrategy, compatibilityPath.interactionSourceStrategy)
+    }
+
+    @Test
+    fun existingBenchmarkVariantsRemainAvailable() {
+        assertEquals(
+            BenchmarkItemImplementation.StyledClickable,
+            benchmarkStyleVariant("current_traversal").implementation,
+        )
+        assertEquals(
+            BenchmarkInteractionSourceStrategy.Explicit,
+            benchmarkStyleVariant("current_traversal").interactionSourceStrategy,
+        )
+        assertEquals(
+            BenchmarkItemImplementation.CandidateComposite,
+            benchmarkStyleVariant("candidate_composite").implementation,
+        )
+        assertEquals(
+            BenchmarkItemImplementation.MaterialSurface,
+            benchmarkStyleVariant("material_surface").implementation,
+        )
+    }
+
+    @Test
+    fun recompositionDriverPublishesMarkerOnlyAfterApplication() {
+        val driver = BenchmarkRecompositionDriver()
+
+        assertEquals(0, driver.generation)
+        assertEquals("benchmark-recomposition-0", driver.marker)
+
+        assertEquals(1, driver.advance())
+        assertEquals(1, driver.generation)
+        assertEquals("benchmark-recomposition-0", driver.marker)
+
+        driver.acknowledgeApplied(1)
+
+        assertEquals("benchmark-recomposition-1", driver.marker)
+    }
+}

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -3,6 +3,7 @@
 package io.daio.android.tv
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import org.junit.Assert.assertEquals
@@ -84,6 +85,8 @@ class TvBenchmarkScenarioTest {
         composeRule.setContent {
             val explicitGeneration = explicitDriver.generation
             val compatibilityGeneration = compatibilityDriver.generation
+            val explicitMarkerDuringComposition = explicitDriver.marker
+            val compatibilityMarkerDuringComposition = compatibilityDriver.marker
             Box {
                 BenchmarkSourcePathItem(
                     variant = benchmarkStyleVariant("explicit_source_fast_path"),
@@ -94,8 +97,12 @@ class TvBenchmarkScenarioTest {
                     recompositionDriver = compatibilityDriver,
                 )
             }
-            explicitMarkersDuringComposition += explicitGeneration to explicitDriver.marker
-            compatibilityMarkersDuringComposition += compatibilityGeneration to compatibilityDriver.marker
+            SideEffect {
+                explicitMarkersDuringComposition +=
+                    explicitGeneration to explicitMarkerDuringComposition
+                compatibilityMarkersDuringComposition +=
+                    compatibilityGeneration to compatibilityMarkerDuringComposition
+            }
         }
 
         composeRule.runOnIdle {


### PR DESCRIPTION
## Summary

This is the third PR in the THE-220 stack, based on #328.

- add explicit-source fast-path versus null-source compatibility benchmark scenarios
- add unchanged-recomposition and source-path wiring coverage through the Android TV benchmark renderer
- document benchmark setup and connected-device limitations
- preserve deterministic focus, terminal markers, and benchmark metrics

Linear: https://linear.app/the-good-egg-studio/issue/THE-220/remove-composed-from-styled-clickableselectable-fast-paths

## Validation

- `:playbook:androidTv:testDebugUnitTest`
- `:internal:benchmark:assemble`
- `:internal:benchmark:assembleAndroidTest`

Connected macrobenchmarks require a physical or representative Android TV device and were not run in this environment.