### PR TITLE
fix: make TV scroll-grid benchmarks reliable on Fire TV

### DIFF
--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -51,6 +51,10 @@ Run at least two invocations and compare variance before making performance conc
 
 The macrobenchmarks use warm startup, 20 measured iterations, `CompilationMode.Partial()`, `FrameTimingMetric`, and `MemoryUsageMetric(Mode.Max)`. Record the device model, Android version, build type, Compose version, compilation mode, iteration count, and item count with exported benchmark results.
 
+On Fire TV / nested `LazyRow` grids, the harness uses a hard `SystemClock.sleep` pace between
+DPAD keys (not only `waitForIdle`) and re-scrolls horizontally after vertical moves so the
+terminal focus target remains reachable. Compare runs only when they share that same input pace.
+
 Report median and tail frame times, missed or overrun frames, max memory usage, and run-to-run variance. Establish a baseline before adding regression thresholds.
 
 Peak memory supports a relative allocation-pressure comparison but is not an exact allocation count.

--- a/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.benchmark
 
+import android.os.SystemClock
 import android.view.KeyEvent
 import androidx.benchmark.macro.CompilationMode
 import androidx.benchmark.macro.ExperimentalMetricApi
@@ -27,8 +28,8 @@ private const val GRID_MODE = "grid"
 private const val FIRST_FOCUS_TARGET = "benchmark-item-0-0"
 private const val TERMINAL_FOCUS_TARGET = "benchmark-item-5-20"
 private const val RECOMPOSITION_MARKER_PREFIX = "benchmark-recomposition-"
-private const val FOCUS_TARGET_TIMEOUT_MS = 5_000L
-private const val INPUT_PACE_MS = 80L
+private const val FOCUS_TARGET_TIMEOUT_MS = 10_000L
+private const val INPUT_PACE_MS = 250L
 private val BENCHMARK_COMPILATION_MODE = CompilationMode.Partial()
 
 private enum class StyleVariant(val extraValue: String) {
@@ -41,11 +42,12 @@ private enum class StyleVariant(val extraValue: String) {
 
 private val DETERMINISTIC_FOCUS_SEQUENCE =
     listOf(
+        // Nested LazyRows reset column on vertical moves, so re-scroll after DOWN before the
+        // terminal check. Pace is enforced with SystemClock.sleep(INPUT_PACE_MS).
         KeyEvent.KEYCODE_DPAD_RIGHT to 15,
-        KeyEvent.KEYCODE_DPAD_DOWN to 10,
-        KeyEvent.KEYCODE_DPAD_RIGHT to 15,
-        KeyEvent.KEYCODE_DPAD_LEFT to 10,
-        KeyEvent.KEYCODE_DPAD_UP to 5,
+        KeyEvent.KEYCODE_DPAD_DOWN to 5,
+        KeyEvent.KEYCODE_DPAD_RIGHT to 25,
+        KeyEvent.KEYCODE_DPAD_LEFT to 5,
     ).flatMap { (keyCode, count) -> List(count) { keyCode } }
 
 @RunWith(AndroidJUnit4::class)
@@ -128,13 +130,17 @@ private fun UiDevice.runDeterministicFocusSequence(enableRecompositionDriver: Bo
 
     pressKeyCode(KeyEvent.KEYCODE_DPAD_RIGHT)
     waitForIdle()
+    SystemClock.sleep(INPUT_PACE_MS)
     if (enableRecompositionDriver) {
         requestUnchangedRecomposition(++recompositionGeneration)
     }
 
     DETERMINISTIC_FOCUS_SEQUENCE.forEach { keyCode ->
         pressKeyCode(keyCode)
-        waitForIdle(INPUT_PACE_MS)
+        waitForIdle()
+        // Fire TV LazyRow needs a real paced delay; waitForIdle alone returns as soon as the
+        // hierarchy is idle and can drop focus moves before the row has scrolled.
+        SystemClock.sleep(INPUT_PACE_MS)
         if (enableRecompositionDriver) {
             requestUnchangedRecomposition(++recompositionGeneration)
         }
@@ -147,7 +153,8 @@ private fun UiDevice.runDeterministicFocusSequence(enableRecompositionDriver: Bo
 
 private fun UiDevice.requestUnchangedRecomposition(generation: Int) {
     check(pressKeyCode(KeyEvent.KEYCODE_R)) { "Failed to inject recomposition key" }
-    waitForIdle(INPUT_PACE_MS)
+    waitForIdle()
+    SystemClock.sleep(INPUT_PACE_MS)
 
     val marker = recompositionMarker(generation)
     check(wait(Until.hasObject(By.desc(marker)), FOCUS_TARGET_TIMEOUT_MS)) {


### PR DESCRIPTION
## Summary
- Pace deterministic DPAD input with a real `SystemClock.sleep` instead of `waitForIdle(timeout)`, which returns as soon as the hierarchy is idle and drops focus moves on Fire TV `LazyRow`s.
- Re-scroll horizontally after vertical moves so nested `LazyRow` columns don't reset away from the terminal focus target (`benchmark-item-5-20`).
- Keep production iteration count / `CompilationMode.Partial()`; document the Fire TV harness constraints in the benchmark README.

## Test plan
- [ ] `./gradlew :internal:benchmark:connectedCheck -Pandroid.testInstrumentationRunnerArguments.class=io.daio.wild.benchmark.TvBenchmarkTest#scrollGridWithCurrentTraversal` on a Fire TV / AFTR device
- [ ] Confirm the run reaches the terminal focus target without timeout
- [ ] Spot-check that iterations remain 20 and compilation mode remains Partial