### PR TITLE
fix: move style scale animation to draw phase

### DIFF
--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -6,12 +6,16 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.animateTo
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.LayoutModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.findNearestAncestor
+import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.invalidatePlacement
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Constraints
@@ -21,7 +25,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /**
- * Applies the scale to the element as part of the [StyleScopeParentNode].
+ * Applies scale and focus z-index for the traversable style chain.
+ *
+ * Z-index still uses layout [placeWithLayer]. Animated scale is applied at draw time so each
+ * animation frame only [invalidateDraw]s — matching the THE-217 candidate and avoiding layout
+ * work on every scale tick.
  */
 internal class ScaleLayoutElement(
     val zIndex: Float = 0f,
@@ -62,6 +70,7 @@ internal class ScaleLayoutModifier(
     var zIndex: Float,
     var scale: Float,
 ) : LayoutModifierNode,
+    DrawModifierNode,
     Modifier.Node(),
     StyleScopeChildNode {
     private var scaleState = AnimationState(initialValue = scale)
@@ -69,7 +78,7 @@ internal class ScaleLayoutModifier(
         get() = scaleState.value
 
     /**
-     * Invalidation is handled by [updateScale]
+     * Invalidation is handled by [updateScale] / animation frames.
      */
     override val shouldAutoInvalidate: Boolean
         get() = false
@@ -156,9 +165,11 @@ internal class ScaleLayoutModifier(
                     scaleState.animateTo(
                         targetValue = scale,
                         animationSpec = effectiveAnimationSpec,
-                    )
+                    ) {
+                        invalidateDraw()
+                    }
                 } finally {
-                    invalidatePlacement()
+                    invalidateDraw()
                 }
             }
     }
@@ -169,15 +180,25 @@ internal class ScaleLayoutModifier(
     ): MeasureResult {
         val placeable = measurable.measure(constraints)
         return layout(placeable.width, placeable.height) {
-            val animatedScale = scaleState.value
-            if (needsScaleLayer(animatedScale, zIndex)) {
-                placeable.placeWithLayer(0, 0, zIndex = zIndex) {
-                    scaleX = animatedScale
-                    scaleY = animatedScale
-                }
+            if (needsZIndexLayer(zIndex)) {
+                placeable.placeWithLayer(0, 0, zIndex = zIndex) {}
             } else {
                 placeable.place(0, 0)
             }
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        val s = scaleState.value
+        if (needsDrawScale(s)) {
+            val contentDrawScope = this
+            scale(s, s) {
+                with(contentDrawScope) {
+                    drawContent()
+                }
+            }
+        } else {
+            drawContent()
         }
     }
 
@@ -195,10 +216,20 @@ internal class ScaleLayoutModifier(
     }
 }
 
+/** True when layout must install a graphics layer solely for z-index. */
+internal fun needsZIndexLayer(zIndex: Float): Boolean = zIndex != 0f
+
+/** True when draw must apply a non-identity scale. */
+internal fun needsDrawScale(animatedScale: Float): Boolean = animatedScale != 1f
+
+/**
+ * Legacy helper: true when either draw scale or z-index layer is required.
+ * Prefer [needsDrawScale] / [needsZIndexLayer] for new call sites.
+ */
 internal fun needsScaleLayer(
     animatedScale: Float,
     zIndex: Float,
-): Boolean = animatedScale != 1f || zIndex != 0f
+): Boolean = needsDrawScale(animatedScale) || needsZIndexLayer(zIndex)
 
 internal enum class ScaleDefaultAnimationSpecKind {
     Pressed,

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
@@ -18,12 +18,16 @@ class LayerSelectionTest {
     @Test
     fun scaleLayerIsSkippedForDefaultValues() {
         assertFalse(needsScaleLayer(animatedScale = 1f, zIndex = 0f))
+        assertFalse(needsDrawScale(animatedScale = 1f))
+        assertFalse(needsZIndexLayer(zIndex = 0f))
     }
 
     @Test
     fun scaleLayerIsUsedForScaleOrZIndex() {
         assertTrue(needsScaleLayer(animatedScale = 1.01f, zIndex = 0f))
         assertTrue(needsScaleLayer(animatedScale = 1f, zIndex = 0.5f))
+        assertTrue(needsDrawScale(animatedScale = 1.01f))
+        assertTrue(needsZIndexLayer(zIndex = 0.5f))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- move `ScaleLayoutModifier` scale animation updates from placement invalidation to draw invalidation
- keep z-index on the layout layer while applying animated scale in `draw()`
- extend layer selection tests to cover the new draw-scale and z-index helpers

## Test plan
- [x] `./gradlew :style:jvmTest --tests \"io.daio.wild.style.modifiers.LayerSelectionTest\" --tests \"io.daio.wild.style.modifiers.ScaleAnimationRequestTest\"`