### PR TITLE
perf: cache style scale animation in a GraphicsLayer

### DIFF
--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -6,8 +6,10 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.animateTo
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
-import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
@@ -17,6 +19,7 @@ import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.findNearestAncestor
 import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.invalidatePlacement
+import androidx.compose.ui.node.requireGraphicsContext
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Constraints
 import io.daio.wild.style.StyleScope
@@ -27,9 +30,9 @@ import kotlinx.coroutines.launch
 /**
  * Applies scale and focus z-index for the traversable style chain.
  *
- * Z-index still uses layout [placeWithLayer]. Animated scale is applied at draw time so each
- * animation frame only [invalidateDraw]s — matching the THE-217 candidate and avoiding layout
- * work on every scale tick.
+ * Z-index still uses layout [placeWithLayer]. Animated scale is applied via a cached
+ * [GraphicsLayer] so animation frames update the layer transform without re-recording
+ * background/border/content drawing commands.
  */
 internal class ScaleLayoutElement(
     val zIndex: Float = 0f,
@@ -88,8 +91,17 @@ internal class ScaleLayoutModifier(
         get() = updateJob?.isActive == true
     private val animationRequestCoalescer = ScaleAnimationRequestCoalescer()
 
+    /** Cached display list for scaled content; transforms update without re-record. */
+    private var graphicsLayer: GraphicsLayer? = null
+    private var layerContentStale: Boolean = true
+    private var recordedSize: Size = Size.Unspecified
+
     override fun onAttach() {
         requestInitialStyleFromParent()
+    }
+
+    override fun onDetach() {
+        releaseGraphicsLayer()
     }
 
     override fun onReset() {
@@ -100,6 +112,17 @@ internal class ScaleLayoutModifier(
         scale = 1f
         zIndex = 0f
         customAnimationSpec = null
+        releaseGraphicsLayer()
+    }
+
+    private fun releaseGraphicsLayer() {
+        val layer = graphicsLayer ?: return
+        graphicsLayer = null
+        layerContentStale = true
+        recordedSize = Size.Unspecified
+        if (isAttached && !layer.isReleased) {
+            requireGraphicsContext().releaseGraphicsLayer(layer)
+        }
     }
 
     fun updateScale(
@@ -166,6 +189,7 @@ internal class ScaleLayoutModifier(
                         targetValue = scale,
                         animationSpec = effectiveAnimationSpec,
                     ) {
+                        // Transform-only: keep the recorded layer, just invalidate draw.
                         invalidateDraw()
                     }
                 } finally {
@@ -190,20 +214,33 @@ internal class ScaleLayoutModifier(
 
     override fun ContentDrawScope.draw() {
         val s = scaleState.value
-        if (needsDrawScale(s)) {
-            val contentDrawScope = this
-            scale(s, s) {
-                with(contentDrawScope) {
-                    drawContent()
-                }
-            }
-        } else {
+        if (!needsDrawScale(s)) {
             drawContent()
+            return
         }
+
+        val layer =
+            graphicsLayer
+                ?: requireGraphicsContext().createGraphicsLayer().also { graphicsLayer = it }
+
+        if (layerContentStale || size != recordedSize) {
+            val contentDrawScope = this
+            layer.record {
+                contentDrawScope.drawContent()
+            }
+            layerContentStale = false
+            recordedSize = size
+        }
+
+        layer.scaleX = s
+        layer.scaleY = s
+        drawLayer(layer)
     }
 
     override fun updateStyle(styleScope: StyleScope) {
         if (!isAttached) return
+        // Sibling style nodes (bg/border) may have new drawing commands — re-record once.
+        layerContentStale = true
         customAnimationSpec = styleScope.scaleAnimationSpec
         updateScale(
             scale = styleScope.scale,
@@ -213,6 +250,7 @@ internal class ScaleLayoutModifier(
             hovered = styleScope.hovered,
             animationSpec = styleScope.scaleAnimationSpec,
         )
+        invalidateDraw()
     }
 }
 

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/ScaleLayoutElement.kt
@@ -6,10 +6,8 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.animateTo
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
-import androidx.compose.ui.graphics.layer.GraphicsLayer
-import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
@@ -19,7 +17,6 @@ import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.findNearestAncestor
 import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.invalidatePlacement
-import androidx.compose.ui.node.requireGraphicsContext
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Constraints
 import io.daio.wild.style.StyleScope
@@ -30,9 +27,9 @@ import kotlinx.coroutines.launch
 /**
  * Applies scale and focus z-index for the traversable style chain.
  *
- * Z-index still uses layout [placeWithLayer]. Animated scale is applied via a cached
- * [GraphicsLayer] so animation frames update the layer transform without re-recording
- * background/border/content drawing commands.
+ * Descendant content is cached in Compose's owned [placeWithLayer], while scale remains a draw
+ * transform so it does not affect descendant coordinates. Animation frames replay the owned layer
+ * without re-recording its content.
  */
 internal class ScaleLayoutElement(
     val zIndex: Float = 0f,
@@ -79,6 +76,7 @@ internal class ScaleLayoutModifier(
     private var scaleState = AnimationState(initialValue = scale)
     internal val animatedScale: Float
         get() = scaleState.value
+    private var scaleLayerActive = needsDrawScale(scale)
 
     /**
      * Invalidation is handled by [updateScale] / animation frames.
@@ -91,17 +89,8 @@ internal class ScaleLayoutModifier(
         get() = updateJob?.isActive == true
     private val animationRequestCoalescer = ScaleAnimationRequestCoalescer()
 
-    /** Cached display list for scaled content; transforms update without re-record. */
-    private var graphicsLayer: GraphicsLayer? = null
-    private var layerContentStale: Boolean = true
-    private var recordedSize: Size = Size.Unspecified
-
     override fun onAttach() {
         requestInitialStyleFromParent()
-    }
-
-    override fun onDetach() {
-        releaseGraphicsLayer()
     }
 
     override fun onReset() {
@@ -109,20 +98,10 @@ internal class ScaleLayoutModifier(
         updateJob = null
         animationRequestCoalescer.reset()
         scaleState = AnimationState(initialValue = 1f)
+        scaleLayerActive = false
         scale = 1f
         zIndex = 0f
         customAnimationSpec = null
-        releaseGraphicsLayer()
-    }
-
-    private fun releaseGraphicsLayer() {
-        val layer = graphicsLayer ?: return
-        graphicsLayer = null
-        layerContentStale = true
-        recordedSize = Size.Unspecified
-        if (isAttached && !layer.isReleased) {
-            requireGraphicsContext().releaseGraphicsLayer(layer)
-        }
     }
 
     fun updateScale(
@@ -160,6 +139,10 @@ internal class ScaleLayoutModifier(
             this.zIndex = zIndex
             invalidatePlacement()
         }
+        if (!scaleLayerActive && needsDrawScale(scale)) {
+            scaleLayerActive = true
+            invalidatePlacement()
+        }
 
         if (
             !animationRequestCoalescer.shouldAnimate(
@@ -189,10 +172,17 @@ internal class ScaleLayoutModifier(
                         targetValue = scale,
                         animationSpec = effectiveAnimationSpec,
                     ) {
-                        // Transform-only: keep the recorded layer, just invalidate draw.
                         invalidateDraw()
                     }
                 } finally {
+                    if (
+                        scaleLayerActive &&
+                        !needsDrawScale(this@ScaleLayoutModifier.scale) &&
+                        !needsDrawScale(scaleState.value)
+                    ) {
+                        scaleLayerActive = false
+                        invalidatePlacement()
+                    }
                     invalidateDraw()
                 }
             }
@@ -204,7 +194,7 @@ internal class ScaleLayoutModifier(
     ): MeasureResult {
         val placeable = measurable.measure(constraints)
         return layout(placeable.width, placeable.height) {
-            if (needsZIndexLayer(zIndex)) {
+            if (scaleLayerActive || needsZIndexLayer(zIndex)) {
                 placeable.placeWithLayer(0, 0, zIndex = zIndex) {}
             } else {
                 placeable.place(0, 0)
@@ -213,34 +203,21 @@ internal class ScaleLayoutModifier(
     }
 
     override fun ContentDrawScope.draw() {
-        val s = scaleState.value
-        if (!needsDrawScale(s)) {
-            drawContent()
-            return
-        }
-
-        val layer =
-            graphicsLayer
-                ?: requireGraphicsContext().createGraphicsLayer().also { graphicsLayer = it }
-
-        if (layerContentStale || size != recordedSize) {
+        val animatedScale = scaleState.value
+        if (needsDrawScale(animatedScale)) {
             val contentDrawScope = this
-            layer.record {
-                contentDrawScope.drawContent()
+            scale(animatedScale, animatedScale) {
+                with(contentDrawScope) {
+                    drawContent()
+                }
             }
-            layerContentStale = false
-            recordedSize = size
+        } else {
+            drawContent()
         }
-
-        layer.scaleX = s
-        layer.scaleY = s
-        drawLayer(layer)
     }
 
     override fun updateStyle(styleScope: StyleScope) {
         if (!isAttached) return
-        // Sibling style nodes (bg/border) may have new drawing commands — re-record once.
-        layerContentStale = true
         customAnimationSpec = styleScope.scaleAnimationSpec
         updateScale(
             scale = styleScope.scale,
@@ -250,7 +227,6 @@ internal class ScaleLayoutModifier(
             hovered = styleScope.hovered,
             animationSpec = styleScope.scaleAnimationSpec,
         )
-        invalidateDraw()
     }
 }
 
@@ -259,15 +235,6 @@ internal fun needsZIndexLayer(zIndex: Float): Boolean = zIndex != 0f
 
 /** True when draw must apply a non-identity scale. */
 internal fun needsDrawScale(animatedScale: Float): Boolean = animatedScale != 1f
-
-/**
- * Legacy helper: true when either draw scale or z-index layer is required.
- * Prefer [needsDrawScale] / [needsZIndexLayer] for new call sites.
- */
-internal fun needsScaleLayer(
-    animatedScale: Float,
-    zIndex: Float,
-): Boolean = needsDrawScale(animatedScale) || needsZIndexLayer(zIndex)
 
 internal enum class ScaleDefaultAnimationSpecKind {
     Pressed,

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/LayerSelectionTest.kt
@@ -17,15 +17,12 @@ import kotlin.test.assertTrue
 class LayerSelectionTest {
     @Test
     fun scaleLayerIsSkippedForDefaultValues() {
-        assertFalse(needsScaleLayer(animatedScale = 1f, zIndex = 0f))
         assertFalse(needsDrawScale(animatedScale = 1f))
         assertFalse(needsZIndexLayer(zIndex = 0f))
     }
 
     @Test
     fun scaleLayerIsUsedForScaleOrZIndex() {
-        assertTrue(needsScaleLayer(animatedScale = 1.01f, zIndex = 0f))
-        assertTrue(needsScaleLayer(animatedScale = 1f, zIndex = 0.5f))
         assertTrue(needsDrawScale(animatedScale = 1.01f))
         assertTrue(needsZIndexLayer(zIndex = 0.5f))
     }

--- a/style/src/jvmTest/kotlin/io/daio/wild/style/modifiers/StyleLayerRenderingTest.kt
+++ b/style/src/jvmTest/kotlin/io/daio/wild/style/modifiers/StyleLayerRenderingTest.kt
@@ -5,6 +5,7 @@ package io.daio.wild.style.modifiers
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -28,7 +29,9 @@ import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -223,6 +226,80 @@ class StyleLayerRenderingTest {
                 interactionSource.emit(PressInteraction.Release(press))
                 interactionSource.emit(FocusInteraction.Unfocus(focus))
             }
+        }
+
+    @Test
+    fun scaledLayerReflectsDescendantDrawChanges() =
+        runComposeUiTest {
+            var contentColor by mutableStateOf(Color.Red)
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(SurfaceSize)
+                            .background(Color.Blue)
+                            .testTag("scaled-content"),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        Modifier
+                            .size(24.dp)
+                            .interactionStyle(null) {
+                                scale = 0.75f
+                                scaleAnimationSpec = snap()
+                            }
+                            .background(contentColor),
+                    )
+                }
+            }
+            waitForIdle()
+
+            onNodeWithTag("scaled-content").captureToImage().centerColor().assertCloseTo(Color.Red)
+
+            runOnIdle { contentColor = Color.Green }
+            waitForIdle()
+
+            onNodeWithTag("scaled-content").captureToImage().centerColor().assertCloseTo(Color.Green)
+        }
+
+    @Test
+    fun scaleDoesNotExpandDescendantHitBounds() =
+        runComposeUiTest {
+            var clicks = 0
+
+            setContent {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(120.dp)
+                            .testTag("scaled-hit-root"),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        Modifier
+                            .size(60.dp)
+                            .interactionStyle(null) {
+                                scale = 2f
+                                scaleAnimationSpec = snap()
+                            },
+                    ) {
+                        Box(
+                            Modifier
+                                .fillMaxSize()
+                                .clickable { clicks++ },
+                        )
+                    }
+                }
+            }
+            waitForIdle()
+
+            onNodeWithTag("scaled-hit-root").performTouchInput {
+                click(Offset(x = 10f, y = center.y))
+            }
+            waitForIdle()
+
+            assertEquals(0, clicks)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- builds on #337 draw-time scale: keep z-index in layout and visual scale in draw so descendant hit coordinates stay unchanged
- cache descendant drawing in a Compose-owned identity layer while scale is active
- replay the owned layer on animation frames without re-recording background, border, or content
- let Compose manage descendant draw, density, layout-direction, and layer lifecycle invalidation
- remove the manual graphics-layer cache and unused legacy layer-selection helper

## Context
Short-harness TV benches on Fire TV showed this within noise of warm draw-scale runs (slight focus P99 lean), but the approach is the natural next step after draw-time scale. Base is #337 so this PR stays a small delta.

## Test plan
- [x] `./gradlew :style:jvmTest :style:spotlessCheck :style:detekt :style:metalavaCheckCompatibility`
- [x] regression: descendant pixels update while scaled
- [x] regression: visual scale does not expand descendant hit bounds
- [ ] Manual: focus/hover scale animation still looks correct in playbook TV/desktop
- [ ] Optional: long confirmation bench after #337 lands (full path, 10–20 iters, `Partial`, cold device)