### PR TITLE
chore(benchmark): harden TV harness for reliable DPAD runs

### DIFF
--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -49,7 +49,30 @@ Run at least two invocations and compare variance before making performance conc
 ./gradlew :internal:benchmark:connectedCheck
 ```
 
-The macrobenchmarks use warm startup, 20 measured iterations, `CompilationMode.Partial()`, `FrameTimingMetric`, and `MemoryUsageMetric(Mode.Max)`. Record the device model, Android version, build type, Compose version, compilation mode, iteration count, and item count with exported benchmark results.
+To isolate style-update cost without deep grid scroll, run the horizontal focus-flip pair:
+
+```bash
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class="io.daio.wild.benchmark.TvBenchmarkTest#focusFlipWithCurrentTraversal"
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class="io.daio.wild.benchmark.TvBenchmarkTest#focusFlipWithCandidateComposite"
+```
+
+**Confirmation / release profile (default in `TvBenchmarkTest`):** warm startup, 20 measured
+iterations, `CompilationMode.Partial()`, full scroll path ending at `benchmark-item-5-20`, plus
+`focusFlip*` cases. Keys use a fixed ~50ms `SystemClock.sleep` pace (not only `waitForIdle`) so
+bursty DPAD input stays comparable across devices. Nested `LazyRow` grids reset column on vertical
+moves, so scroll sequences re-scroll horizontally after each `DOWN`. The playbook grid centers
+focused items with `BringIntoViewSpec` so scroll stays aligned under rapid focus moves.
+`FrameTimingMetric` + `MemoryUsageMetric(Mode.Max)`.
+
+**Local optimization profile:** temporarily lower iteration count, use `CompilationMode.None()`,
+and/or shorten the scroll sequence (for example end at `benchmark-item-2-10`). Restore the
+confirmation profile before release claims. Compare runs only when they share the same input pace,
+path, compilation mode, and iteration count.
+
+Record the device model, Android version, build type, Compose version, compilation mode, iteration
+count, and item count with exported benchmark results.
 
 Report median and tail frame times, missed or overrun frames, max memory usage, and run-to-run variance. Establish a baseline before adding regression thresholds.
 

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -49,7 +49,7 @@ Run at least two invocations and compare variance before making performance conc
 ./gradlew :internal:benchmark:connectedCheck
 ```
 
-To isolate style-update cost without deep grid scroll, run the horizontal focus-flip pair:
+To isolate style-update cost without lazy scrolling, run the two-item focus-flip pair:
 
 ```bash
 ./gradlew :internal:benchmark:connectedCheck \
@@ -60,10 +60,11 @@ To isolate style-update cost without deep grid scroll, run the horizontal focus-
 
 **Confirmation / release profile (default in `TvBenchmarkTest`):** warm startup, 20 measured
 iterations, `CompilationMode.Partial()`, full scroll path ending at `benchmark-item-5-20`, plus
-`focusFlip*` cases. Keys use a fixed ~50ms `SystemClock.sleep` pace (not only `waitForIdle`) so
-bursty DPAD input stays comparable across devices. Nested `LazyRow` grids reset column on vertical
-moves, so scroll sequences re-scroll horizontally after each `DOWN`. The playbook grid centers
-focused items with `BringIntoViewSpec` so scroll stays aligned under rapid focus moves.
+`focusFlip*` cases that alternate between two stationary items. Keys use a fixed ~50ms
+`SystemClock.sleep` pace (not only `waitForIdle`) so bursty DPAD input stays comparable across
+devices. Nested `LazyRow` grids reset column on vertical moves, so scroll sequences re-scroll
+horizontally after each `DOWN`. The playbook grid centers focused items with `BringIntoViewSpec` so
+scroll stays aligned under rapid focus moves.
 `FrameTimingMetric` + `MemoryUsageMetric(Mode.Max)`.
 
 **Local optimization profile:** temporarily lower iteration count, use `CompilationMode.None()`,

--- a/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
@@ -30,9 +30,10 @@ private const val MODE_EXTRA = "MODE"
 private const val ITEMS_EXTRA = "ITEMS"
 private const val RECOMPOSITION_DRIVER_EXTRA = "RECOMPOSITION_DRIVER"
 private const val GRID_MODE = "grid"
+private const val FOCUS_FLIP_MODE = "focus_flip"
 private const val FIRST_FOCUS_TARGET = "benchmark-item-0-0"
 private const val SCROLL_TERMINAL_FOCUS_TARGET = "benchmark-item-5-20"
-private const val FOCUS_FLIP_TERMINAL_TARGET = "benchmark-item-0-15"
+private const val FOCUS_FLIP_TERMINAL_TARGET = "benchmark-item-0-1"
 private const val RECOMPOSITION_MARKER_PREFIX = "benchmark-recomposition-"
 private const val FOCUS_TARGET_TIMEOUT_MS = 10_000L
 
@@ -70,12 +71,14 @@ private val SCROLL_GRID_FOCUS_SEQUENCE =
         repeat(5) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
     }
 
-/** Horizontal focus flips — isolates style update cost vs deep grid scroll. */
+/** Alternates focus between two stationary items, then ends on the second item. */
 private val FOCUS_FLIP_SEQUENCE =
     buildList {
-        repeat(15) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
-        repeat(15) { add(KeyEvent.KEYCODE_DPAD_LEFT) }
-        repeat(15) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
+        repeat(15) {
+            add(KeyEvent.KEYCODE_DPAD_RIGHT)
+            add(KeyEvent.KEYCODE_DPAD_LEFT)
+        }
+        add(KeyEvent.KEYCODE_DPAD_RIGHT)
     }
 
 @RunWith(AndroidJUnit4::class)
@@ -105,6 +108,7 @@ class TvBenchmarkTest {
     fun focusFlipWithCurrentTraversal() {
         benchmarkRule.measureStyleVariant(
             variant = StyleVariant.CurrentTraversal,
+            mode = FOCUS_FLIP_MODE,
             focusSequence = FOCUS_FLIP_SEQUENCE,
             terminalFocusTarget = FOCUS_FLIP_TERMINAL_TARGET,
         )
@@ -114,6 +118,7 @@ class TvBenchmarkTest {
     fun focusFlipWithCandidateComposite() {
         benchmarkRule.measureStyleVariant(
             variant = StyleVariant.CandidateComposite,
+            mode = FOCUS_FLIP_MODE,
             focusSequence = FOCUS_FLIP_SEQUENCE,
             terminalFocusTarget = FOCUS_FLIP_TERMINAL_TARGET,
         )
@@ -151,6 +156,7 @@ class TvBenchmarkTest {
 
 private fun MacrobenchmarkRule.measureStyleVariant(
     variant: StyleVariant,
+    mode: String = GRID_MODE,
     focusSequence: List<Int>,
     terminalFocusTarget: String,
     enableRecompositionDriver: Boolean = false,
@@ -163,12 +169,17 @@ private fun MacrobenchmarkRule.measureStyleVariant(
         iterations = DEFAULT_ITERATIONS,
         setupBlock = {
             startActivityAndWait {
-                it.putExtra(MODE_EXTRA, GRID_MODE)
+                it.putExtra(MODE_EXTRA, mode)
                 it.putExtra(ITEMS_EXTRA, variant.extraValue)
                 it.putExtra(RECOMPOSITION_DRIVER_EXTRA, enableRecompositionDriver)
             }
             device.waitForIdle()
-            check(device.wait(Until.hasObject(By.desc(FIRST_FOCUS_TARGET)), FOCUS_TARGET_TIMEOUT_MS)) {
+            check(
+                device.wait(
+                    Until.hasObject(By.desc(FIRST_FOCUS_TARGET).focused(true)),
+                    FOCUS_TARGET_TIMEOUT_MS,
+                ),
+            ) {
                 "Timed out waiting for first benchmark focus target $FIRST_FOCUS_TARGET"
             }
             if (enableRecompositionDriver) {
@@ -201,14 +212,19 @@ private fun UiDevice.runDeterministicFocusSequence(
     var recompositionGeneration = 0
 
     focusSequence.forEach { keyCode ->
-        pressKeyCode(keyCode)
+        check(pressKeyCode(keyCode)) { "Failed to inject DPAD key $keyCode" }
         SystemClock.sleep(INPUT_FRAME_PACE_MS)
         if (enableRecompositionDriver) {
             requestUnchangedRecomposition(++recompositionGeneration)
         }
     }
 
-    check(wait(Until.hasObject(By.desc(terminalFocusTarget)), FOCUS_TARGET_TIMEOUT_MS)) {
+    check(
+        wait(
+            Until.hasObject(By.desc(terminalFocusTarget).focused(true)),
+            FOCUS_TARGET_TIMEOUT_MS,
+        ),
+    ) {
         "Timed out waiting for terminal benchmark focus target $terminalFocusTarget"
     }
 }

--- a/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/io/daio/wild/benchmark/TvBenchmarkTest.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.daio.wild.benchmark
 
+import android.os.SystemClock
 import android.view.KeyEvent
 import androidx.benchmark.macro.CompilationMode
 import androidx.benchmark.macro.ExperimentalMetricApi
@@ -18,6 +19,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * Confirmation / release profile. For faster local iteration, temporarily lower
+ * [DEFAULT_ITERATIONS], switch [BENCHMARK_COMPILATION_MODE] to [CompilationMode.None], and/or
+ * shorten [SCROLL_GRID_FOCUS_SEQUENCE]. Restore this profile before release claims.
+ */
 private const val DEFAULT_ITERATIONS = 20
 private const val APP_PACKAGE = "io.daio.wild.playbook.tv"
 private const val MODE_EXTRA = "MODE"
@@ -25,10 +31,16 @@ private const val ITEMS_EXTRA = "ITEMS"
 private const val RECOMPOSITION_DRIVER_EXTRA = "RECOMPOSITION_DRIVER"
 private const val GRID_MODE = "grid"
 private const val FIRST_FOCUS_TARGET = "benchmark-item-0-0"
-private const val TERMINAL_FOCUS_TARGET = "benchmark-item-5-20"
+private const val SCROLL_TERMINAL_FOCUS_TARGET = "benchmark-item-5-20"
+private const val FOCUS_FLIP_TERMINAL_TARGET = "benchmark-item-0-15"
 private const val RECOMPOSITION_MARKER_PREFIX = "benchmark-recomposition-"
-private const val FOCUS_TARGET_TIMEOUT_MS = 5_000L
-private const val INPUT_PACE_MS = 80L
+private const val FOCUS_TARGET_TIMEOUT_MS = 10_000L
+
+/**
+ * Fixed delay between DPAD keys. Prefer this over [UiDevice.waitForIdle] alone so bursty focus
+ * moves stay paced across devices; compare runs only when they share the same pace.
+ */
+private const val INPUT_FRAME_PACE_MS = 50L
 private val BENCHMARK_COMPILATION_MODE = CompilationMode.Partial()
 
 private enum class StyleVariant(val extraValue: String) {
@@ -39,14 +51,32 @@ private enum class StyleVariant(val extraValue: String) {
     MaterialSurface("material_surface"),
 }
 
-private val DETERMINISTIC_FOCUS_SEQUENCE =
-    listOf(
-        KeyEvent.KEYCODE_DPAD_RIGHT to 15,
-        KeyEvent.KEYCODE_DPAD_DOWN to 10,
-        KeyEvent.KEYCODE_DPAD_RIGHT to 15,
-        KeyEvent.KEYCODE_DPAD_LEFT to 10,
-        KeyEvent.KEYCODE_DPAD_UP to 5,
-    ).flatMap { (keyCode, count) -> List(count) { keyCode } }
+/**
+ * Full scroll/focus path for confirmation runs. Nested [LazyRow]s reset column on DOWN, so the
+ * sequence re-scrolls horizontally after each vertical move. The playbook grid centers focused
+ * items via [androidx.compose.foundation.gestures.BringIntoViewSpec].
+ *
+ * For local optimization loops, shorten this path (for example end at `benchmark-item-2-10`) and
+ * temporarily lower [DEFAULT_ITERATIONS] / use [CompilationMode.None].
+ */
+private val SCROLL_GRID_FOCUS_SEQUENCE =
+    buildList {
+        repeat(20) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
+        repeat(5) {
+            add(KeyEvent.KEYCODE_DPAD_DOWN)
+            repeat(20) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
+        }
+        repeat(5) { add(KeyEvent.KEYCODE_DPAD_LEFT) }
+        repeat(5) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
+    }
+
+/** Horizontal focus flips — isolates style update cost vs deep grid scroll. */
+private val FOCUS_FLIP_SEQUENCE =
+    buildList {
+        repeat(15) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
+        repeat(15) { add(KeyEvent.KEYCODE_DPAD_LEFT) }
+        repeat(15) { add(KeyEvent.KEYCODE_DPAD_RIGHT) }
+    }
 
 @RunWith(AndroidJUnit4::class)
 class TvBenchmarkTest {
@@ -55,23 +85,55 @@ class TvBenchmarkTest {
 
     @Test
     fun scrollGridWithCurrentTraversal() {
-        benchmarkRule.measureStyleVariant(StyleVariant.CurrentTraversal)
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.CurrentTraversal,
+            focusSequence = SCROLL_GRID_FOCUS_SEQUENCE,
+            terminalFocusTarget = SCROLL_TERMINAL_FOCUS_TARGET,
+        )
     }
 
     @Test
     fun scrollGridWithCandidateComposite() {
-        benchmarkRule.measureStyleVariant(StyleVariant.CandidateComposite)
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.CandidateComposite,
+            focusSequence = SCROLL_GRID_FOCUS_SEQUENCE,
+            terminalFocusTarget = SCROLL_TERMINAL_FOCUS_TARGET,
+        )
+    }
+
+    @Test
+    fun focusFlipWithCurrentTraversal() {
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.CurrentTraversal,
+            focusSequence = FOCUS_FLIP_SEQUENCE,
+            terminalFocusTarget = FOCUS_FLIP_TERMINAL_TARGET,
+        )
+    }
+
+    @Test
+    fun focusFlipWithCandidateComposite() {
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.CandidateComposite,
+            focusSequence = FOCUS_FLIP_SEQUENCE,
+            terminalFocusTarget = FOCUS_FLIP_TERMINAL_TARGET,
+        )
     }
 
     @Test
     fun scrollGridWithMaterialSurface() {
-        benchmarkRule.measureStyleVariant(StyleVariant.MaterialSurface)
+        benchmarkRule.measureStyleVariant(
+            variant = StyleVariant.MaterialSurface,
+            focusSequence = SCROLL_GRID_FOCUS_SEQUENCE,
+            terminalFocusTarget = SCROLL_TERMINAL_FOCUS_TARGET,
+        )
     }
 
     @Test
     fun recomposeUnchangedGridWithExplicitSourceFastPath() {
         benchmarkRule.measureStyleVariant(
             variant = StyleVariant.ExplicitSourceFastPath,
+            focusSequence = SCROLL_GRID_FOCUS_SEQUENCE,
+            terminalFocusTarget = SCROLL_TERMINAL_FOCUS_TARGET,
             enableRecompositionDriver = true,
         )
     }
@@ -80,6 +142,8 @@ class TvBenchmarkTest {
     fun recomposeUnchangedGridWithNullSourceCompatibility() {
         benchmarkRule.measureStyleVariant(
             variant = StyleVariant.NullSourceCompatibility,
+            focusSequence = SCROLL_GRID_FOCUS_SEQUENCE,
+            terminalFocusTarget = SCROLL_TERMINAL_FOCUS_TARGET,
             enableRecompositionDriver = true,
         )
     }
@@ -87,6 +151,8 @@ class TvBenchmarkTest {
 
 private fun MacrobenchmarkRule.measureStyleVariant(
     variant: StyleVariant,
+    focusSequence: List<Int>,
+    terminalFocusTarget: String,
     enableRecompositionDriver: Boolean = false,
 ) {
     measureRepeated(
@@ -112,7 +178,11 @@ private fun MacrobenchmarkRule.measureStyleVariant(
             }
         },
     ) {
-        device.runDeterministicFocusSequence(enableRecompositionDriver)
+        device.runDeterministicFocusSequence(
+            focusSequence = focusSequence,
+            terminalFocusTarget = terminalFocusTarget,
+            enableRecompositionDriver = enableRecompositionDriver,
+        )
     }
 }
 
@@ -123,31 +193,29 @@ private fun styleMetrics(): List<Metric> =
         MemoryUsageMetric(MemoryUsageMetric.Mode.Max),
     )
 
-private fun UiDevice.runDeterministicFocusSequence(enableRecompositionDriver: Boolean) {
+private fun UiDevice.runDeterministicFocusSequence(
+    focusSequence: List<Int>,
+    terminalFocusTarget: String,
+    enableRecompositionDriver: Boolean,
+) {
     var recompositionGeneration = 0
 
-    pressKeyCode(KeyEvent.KEYCODE_DPAD_RIGHT)
-    waitForIdle()
-    if (enableRecompositionDriver) {
-        requestUnchangedRecomposition(++recompositionGeneration)
-    }
-
-    DETERMINISTIC_FOCUS_SEQUENCE.forEach { keyCode ->
+    focusSequence.forEach { keyCode ->
         pressKeyCode(keyCode)
-        waitForIdle(INPUT_PACE_MS)
+        SystemClock.sleep(INPUT_FRAME_PACE_MS)
         if (enableRecompositionDriver) {
             requestUnchangedRecomposition(++recompositionGeneration)
         }
     }
 
-    check(wait(Until.hasObject(By.desc(TERMINAL_FOCUS_TARGET)), FOCUS_TARGET_TIMEOUT_MS)) {
-        "Timed out waiting for terminal benchmark focus target $TERMINAL_FOCUS_TARGET"
+    check(wait(Until.hasObject(By.desc(terminalFocusTarget)), FOCUS_TARGET_TIMEOUT_MS)) {
+        "Timed out waiting for terminal benchmark focus target $terminalFocusTarget"
     }
 }
 
 private fun UiDevice.requestUnchangedRecomposition(generation: Int) {
     check(pressKeyCode(KeyEvent.KEYCODE_R)) { "Failed to inject recomposition key" }
-    waitForIdle(INPUT_PACE_MS)
+    SystemClock.sleep(INPUT_FRAME_PACE_MS)
 
     val marker = recompositionMarker(generation)
     check(wait(Until.hasObject(By.desc(marker)), FOCUS_TARGET_TIMEOUT_MS)) {

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -3,17 +3,24 @@
 package io.daio.android.tv
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.BringIntoViewSpec
+import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableIntStateOf
@@ -38,6 +45,7 @@ import io.daio.wild.style.Border
 import io.daio.wild.style.Style
 import io.daio.wild.style.StyleDefaults
 import io.daio.wild.style.clickable
+import kotlin.math.abs
 import androidx.tv.material3.LocalContentColor as TvLocalContentColor
 
 private const val GRID_ROWS = 20
@@ -248,6 +256,7 @@ internal fun BenchmarkSourcePathItem(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun OptionsGrid(
     variant: StyleVariant,
@@ -256,26 +265,59 @@ private fun OptionsGrid(
 ) {
     val config = remember { BenchmarkItemConfig() }
     val style = remember(config) { config.style }
+    // Center focused items under rapid DPAD so scroll stays aligned without fixed key delays.
+    val bringIntoViewSpec =
+        remember {
+            object : BringIntoViewSpec {
+                override fun calculateScrollDistance(
+                    offset: Float,
+                    size: Float,
+                    containerSize: Float,
+                ): Float {
+                    val trailingEdge = offset + size
+                    val sizeOfItem = abs(trailingEdge - offset)
+                    val childSmallerThanParent = sizeOfItem <= containerSize
+                    val initialTargetForLeadingEdge = containerSize / 2f - sizeOfItem / 2f
+                    val spaceAvailableToShowItem = containerSize - initialTargetForLeadingEdge
+                    val targetForLeadingEdge =
+                        if (childSmallerThanParent && spaceAvailableToShowItem < sizeOfItem) {
+                            containerSize - sizeOfItem
+                        } else {
+                            initialTargetForLeadingEdge
+                        }
+                    return offset - targetForLeadingEdge
+                }
+            }
+        }
 
-    LazyColumn(
-        modifier =
-            modifier
-                .background(Color.Black)
-                .fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        items(GRID_ROWS, key = { it }) { row ->
-            LazyRow {
-                items(GRID_COLUMNS, key = { it }) { column ->
-                    BenchmarkItem(
-                        variant = variant,
-                        title = variant.benchmarkTitle,
-                        style = style,
-                        config = config,
-                        marker = "benchmark-item-$row-$column",
-                        recompositionDriver = recompositionDriver,
-                        onClick = { },
-                    )
+    CompositionLocalProvider(LocalBringIntoViewSpec provides bringIntoViewSpec) {
+        BoxWithConstraints(modifier = modifier.fillMaxSize().background(Color.Black)) {
+            val horizontalPadding = (maxWidth / 2) - (config.itemSize / 2)
+            val verticalPadding = (maxHeight / 2) - (config.itemSize / 2)
+            LazyColumn(
+                contentPadding =
+                    PaddingValues(vertical = verticalPadding.coerceAtLeast(0.dp)),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(GRID_ROWS, key = { it }) { row ->
+                    LazyRow(
+                        contentPadding =
+                            PaddingValues(horizontal = horizontalPadding.coerceAtLeast(0.dp)),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        items(GRID_COLUMNS, key = { it }) { column ->
+                            BenchmarkItem(
+                                variant = variant,
+                                title = variant.benchmarkTitle,
+                                style = style,
+                                config = config,
+                                marker = "benchmark-item-$row-$column",
+                                recompositionDriver = recompositionDriver,
+                                onClick = { },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
+++ b/playbook/androidTv/src/main/java/io/daio/android/tv/TvLayout.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -21,12 +22,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -45,13 +49,13 @@ import io.daio.wild.style.Border
 import io.daio.wild.style.Style
 import io.daio.wild.style.StyleDefaults
 import io.daio.wild.style.clickable
-import kotlin.math.abs
 import androidx.tv.material3.LocalContentColor as TvLocalContentColor
 
 private const val GRID_ROWS = 20
 private const val GRID_COLUMNS = 100
 private const val LIST_ITEMS = 100
 private const val SOURCE_PATH_BENCHMARK_TITLE = "styled_clickable_source_path"
+private const val FOCUS_FLIP_BENCHMARK_TITLE = "style_focus_flip"
 
 internal enum class BenchmarkItemImplementation {
     StyledClickable,
@@ -230,6 +234,7 @@ private fun BenchmarkLayout(
     when (mode) {
         "list" -> OptionsList(variant, modifier, recompositionDriver)
         "grid" -> OptionsGrid(variant, modifier, recompositionDriver)
+        "focus_flip" -> OptionsFocusFlip(variant, modifier, recompositionDriver)
     }
 }
 
@@ -273,20 +278,7 @@ private fun OptionsGrid(
                     offset: Float,
                     size: Float,
                     containerSize: Float,
-                ): Float {
-                    val trailingEdge = offset + size
-                    val sizeOfItem = abs(trailingEdge - offset)
-                    val childSmallerThanParent = sizeOfItem <= containerSize
-                    val initialTargetForLeadingEdge = containerSize / 2f - sizeOfItem / 2f
-                    val spaceAvailableToShowItem = containerSize - initialTargetForLeadingEdge
-                    val targetForLeadingEdge =
-                        if (childSmallerThanParent && spaceAvailableToShowItem < sizeOfItem) {
-                            containerSize - sizeOfItem
-                        } else {
-                            initialTargetForLeadingEdge
-                        }
-                    return offset - targetForLeadingEdge
-                }
+                ): Float = offset + (size - containerSize) / 2f
             }
         }
 
@@ -321,6 +313,45 @@ private fun OptionsGrid(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun OptionsFocusFlip(
+    variant: StyleVariant,
+    modifier: Modifier = Modifier,
+    recompositionDriver: BenchmarkRecompositionDriver? = null,
+) {
+    val config = remember { BenchmarkItemConfig() }
+    val style = remember(config) { config.style }
+    val firstItemFocusRequester = remember { FocusRequester() }
+
+    Row(
+        modifier = modifier.fillMaxSize().background(Color.Black),
+        horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        repeat(2) { column ->
+            BenchmarkItem(
+                variant = variant,
+                title = FOCUS_FLIP_BENCHMARK_TITLE,
+                style = style,
+                config = config,
+                marker = "benchmark-item-0-$column",
+                recompositionDriver = recompositionDriver,
+                onClick = { },
+                modifier =
+                    if (column == 0) {
+                        Modifier.focusRequester(firstItemFocusRequester)
+                    } else {
+                        Modifier
+                    },
+            )
+        }
+    }
+
+    LaunchedEffect(firstItemFocusRequester) {
+        firstItemFocusRequester.requestFocus()
     }
 }
 

--- a/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
+++ b/playbook/androidTv/src/test/java/io/daio/android/tv/TvBenchmarkScenarioTest.kt
@@ -4,8 +4,15 @@ package io.daio.android.tv
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performKeyInput
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -55,6 +62,61 @@ class TvBenchmarkScenarioTest {
             BenchmarkItemImplementation.MaterialSurface,
             benchmarkStyleVariant("material_surface").implementation,
         )
+    }
+
+    @Test
+    fun focusFlipScenarioAlternatesBetweenTwoStationaryTargets() {
+        composeRule.setContent {
+            TvLayout(
+                mode = "focus_flip",
+                itemsType = "current_traversal",
+            )
+        }
+
+        val firstTarget =
+            composeRule
+                .onNodeWithContentDescription("benchmark-item-0-0")
+                .assertIsFocused()
+        val secondTarget =
+            composeRule.onNodeWithContentDescription("benchmark-item-0-1")
+        composeRule
+            .onNodeWithContentDescription("benchmark-item-0-2")
+            .assertDoesNotExist()
+
+        firstTarget.performKeyInput {
+            keyDown(Key.DirectionRight)
+            keyUp(Key.DirectionRight)
+        }
+        secondTarget.assertIsFocused()
+
+        secondTarget.performKeyInput {
+            keyDown(Key.DirectionLeft)
+            keyUp(Key.DirectionLeft)
+        }
+        firstTarget.assertIsFocused()
+    }
+
+    @Test
+    fun focusFlipVariantsRenderIdenticalContent() {
+        val itemsType = mutableStateOf("current_traversal")
+        composeRule.setContent {
+            TvLayout(
+                mode = "focus_flip",
+                itemsType = itemsType.value,
+            )
+        }
+
+        composeRule
+            .onAllNodesWithText("style_focus_flip")
+            .assertCountEquals(2)
+
+        composeRule.runOnIdle {
+            itemsType.value = "candidate_composite"
+        }
+
+        composeRule
+            .onAllNodesWithText("style_focus_flip")
+            .assertCountEquals(2)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- center focused playbook grid items with `BringIntoViewSpec` + content padding so rapid DPAD stays aligned
- pace harness keys with fixed `SystemClock.sleep` (not only `waitForIdle`) and re-scroll after nested `LazyRow` column resets
- add `focusFlip*` cases to isolate style-update cost vs deep scroll
- keep confirmation defaults (20 iters, `Partial`, full path); document a local optimization profile in the README

## Test plan
- [x] `./gradlew :playbook:androidTv:compileDebugKotlin`
- [x] `./gradlew :internal:benchmark:compileDebugKotlin`
- [x] `./gradlew spotlessCheck`
- [ ] Optional device: `scrollGridWithCurrentTraversal` and `focusFlipWithCurrentTraversal` on a physical TV / emulator