### PR TITLE
THE-214 Add thinner static style path for non-interactive containers

### DIFF
--- a/layout/container/src/commonMain/kotlin/io/daio/wild/container/Container.kt
+++ b/layout/container/src/commonMain/kotlin/io/daio/wild/container/Container.kt
@@ -27,7 +27,7 @@ import io.daio.wild.style.Shapes
 import io.daio.wild.style.Style
 import io.daio.wild.style.StyleDefaults
 import io.daio.wild.style.interactable
-import io.daio.wild.style.interactionStyle
+import io.daio.wild.style.staticStyle
 
 /**
  * [Container] is a building block component that can be used for any static element or as an
@@ -53,7 +53,7 @@ fun Container(
 ) {
     Box(
         modifier =
-            modifier.interactionStyle(
+            modifier.staticStyle(
                 style =
                     StyleDefaults.style(
                         colors =
@@ -64,8 +64,6 @@ fun Container(
                         shapes = StyleDefaults.shapes(shape = shape),
                         borders = StyleDefaults.borders(border = border),
                     ),
-                interactionSource = null,
-                enabled = true,
             ),
         propagateMinConstraints = true,
         content = {

--- a/layout/container/src/jvmTest/kotlin/io/daio/wild/container/StaticContainerModifierTest.kt
+++ b/layout/container/src/jvmTest/kotlin/io/daio/wild/container/StaticContainerModifierTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTestApi::class)
 class StaticContainerModifierTest {
     @Test
-    fun doesNotInstallAnInteractionSourceElement() =
+    fun installsStaticStyleWithoutAnInteractionSourceElement() =
         runComposeUiTest {
             setContent {
                 Container(
@@ -31,9 +31,23 @@ class StaticContainerModifierTest {
                     .layoutInfo
                     .modifierInfos()
                     .flatMap { info -> info.modifier().elements() }
+            val elementNames = elements.map { element -> element::class.simpleName }
 
             assertTrue(
-                elements.none { element -> element::class.simpleName == "InteractionSourceElement" },
+                elementNames.containsAll(
+                    listOf(
+                        "StyleScopeParentElement",
+                        "ScaleLayoutElement",
+                        "BorderElement",
+                        "BackgroundElement",
+                        "ShapeLayoutElement",
+                    ),
+                ),
+                elements.toString(),
+            )
+
+            assertTrue(
+                elementNames.none { element -> element == "InteractionSourceElement" },
                 elements.toString(),
             )
         }

--- a/layout/container/src/jvmTest/kotlin/io/daio/wild/container/StaticContainerModifierTest.kt
+++ b/layout/container/src/jvmTest/kotlin/io/daio/wild/container/StaticContainerModifierTest.kt
@@ -1,0 +1,54 @@
+// Copyright 2024, Dai Williams
+// SPDX-License-Identifier: Apache-2.0
+package io.daio.wild.container
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class StaticContainerModifierTest {
+    @Test
+    fun doesNotInstallAnInteractionSourceElement() =
+        runComposeUiTest {
+            setContent {
+                Container(
+                    modifier = Modifier.testTag("static-container").size(48.dp),
+                    color = Color.Red,
+                ) {}
+            }
+
+            val elements =
+                onNodeWithTag("static-container")
+                    .fetchSemanticsNode()
+                    .layoutInfo
+                    .modifierInfos()
+                    .flatMap { info -> info.modifier().elements() }
+
+            assertTrue(
+                elements.none { element -> element::class.simpleName == "InteractionSourceElement" },
+                elements.toString(),
+            )
+        }
+}
+
+private fun Modifier.elements(): List<Modifier.Element> =
+    buildList {
+        foldIn(Unit) { _, element -> add(element) }
+    }
+
+private fun Any.modifierInfos(): List<Any> =
+    javaClass
+        .getMethod("getModifierInfo")
+        .invoke(this)
+        .let { it as List<*> }
+        .filterNotNull()
+
+private fun Any.modifier(): Modifier = javaClass.getMethod("getModifier").invoke(this) as Modifier

--- a/style/api/api.txt
+++ b/style/api/api.txt
@@ -387,6 +387,7 @@ package io.daio.wild.style {
     method @Deprecated public static androidx.compose.ui.Modifier experimentalInteractionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit> block);
     method public static androidx.compose.ui.Modifier interactionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, io.daio.wild.style.Style style);
     method public static androidx.compose.ui.Modifier interactionStyle(androidx.compose.ui.Modifier, androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional boolean enabled, optional boolean selected, kotlin.jvm.functions.Function1<? super io.daio.wild.style.StyleScope,kotlin.Unit> block);
+    method public static androidx.compose.ui.Modifier staticStyle(androidx.compose.ui.Modifier, io.daio.wild.style.Style style);
   }
 
   @io.daio.wild.style.StyleScopeDslMarker public interface StyleScope extends io.daio.wild.foundation.InteractionState {

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Style.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Style.kt
@@ -331,19 +331,29 @@ fun Modifier.interactionStyle(
     selected: Boolean = false,
     style: Style,
 ): Modifier =
-    (
-        if (interactionSource != null) {
-            this.interactionSourceNode(
-                interactionSource = interactionSource,
-                childTraversalKey = StyleParentTraversalKey,
-            )
-        } else {
-            this
-        }
+    this.interactionSourceNode(
+        interactionSource = interactionSource,
+        childTraversalKey = StyleParentTraversalKey,
     ) then
         StyleScopeParentElement(
             enabled = enabled,
             selected = selected,
+            resolver = StyleResolver.Value(style),
+        ) then
+        ScaleLayoutElement() then
+        BorderElement() then
+        BackgroundElement() then
+        ShapeLayoutElement()
+
+/**
+ * Sets a non-interactive [Style] on the element.
+ *
+ * @param style The [Style] to apply to the element.
+ * @since 0.7.0
+ */
+fun Modifier.staticStyle(style: Style): Modifier =
+    this then
+        StyleScopeParentElement(
             resolver = StyleResolver.Value(style),
         ) then
         ScaleLayoutElement() then

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Style.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Style.kt
@@ -21,6 +21,7 @@ import io.daio.wild.style.modifiers.StyleResolver
 import io.daio.wild.style.modifiers.StyleScopeParentElement
 import io.daio.wild.style.modifiers.border
 import io.daio.wild.style.modifiers.interactionSourceNode
+import io.daio.wild.style.modifiers.staticStyleBoundary
 
 /**
  * Style class for components.
@@ -352,7 +353,7 @@ fun Modifier.interactionStyle(
  * @since 0.7.0
  */
 fun Modifier.staticStyle(style: Style): Modifier =
-    this then
+    this.staticStyleBoundary() then
         StyleScopeParentElement(
             resolver = StyleResolver.Value(style),
         ) then

--- a/style/src/commonMain/kotlin/io/daio/wild/style/Style.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/Style.kt
@@ -331,9 +331,15 @@ fun Modifier.interactionStyle(
     selected: Boolean = false,
     style: Style,
 ): Modifier =
-    this.interactionSourceNode(
-        interactionSource = interactionSource,
-        childTraversalKey = StyleParentTraversalKey,
+    (
+        if (interactionSource != null) {
+            this.interactionSourceNode(
+                interactionSource = interactionSource,
+                childTraversalKey = StyleParentTraversalKey,
+            )
+        } else {
+            this
+        }
     ) then
         StyleScopeParentElement(
             enabled = enabled,

--- a/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
+++ b/style/src/commonMain/kotlin/io/daio/wild/style/modifiers/InteractionSourceElement.kt
@@ -35,6 +35,8 @@ fun Modifier.interactionSourceNode(
 
 object DefaultInteractionSourceChildTraversalKey
 
+internal object InteractionSourceTraversalKey
+
 @Immutable
 data class Interactions(
     val focused: Boolean,
@@ -209,8 +211,6 @@ internal class InteractionSourceNode(
     }
 
     private companion object {
-        object InteractionSourceParentKey
-
         const val STATE_NONE = 0
         const val STATE_PRESSED = 1 shl 0
         const val STATE_HOVERED = 1 shl 1
@@ -229,5 +229,17 @@ internal class InteractionSourceNode(
     }
 
     override val traverseKey: Any
-        get() = InteractionSourceParentKey
+        get() = InteractionSourceTraversalKey
+}
+
+internal fun Modifier.staticStyleBoundary(): Modifier = this then StaticStyleBoundaryElement
+
+private data object StaticStyleBoundaryElement : ModifierNodeElement<StaticStyleBoundaryNode>() {
+    override fun create() = StaticStyleBoundaryNode()
+
+    override fun update(node: StaticStyleBoundaryNode) = Unit
+}
+
+internal class StaticStyleBoundaryNode : Modifier.Node(), TraversableNode {
+    override val traverseKey: Any = InteractionSourceTraversalKey
 }

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/StyleTraversalIntegrationTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/StyleTraversalIntegrationTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import io.daio.wild.foundation.ExperimentalWildApi
 import io.daio.wild.style.Border
 import io.daio.wild.style.BorderDefaults
+import io.daio.wild.style.StyleDefaults
 import io.daio.wild.style.interactionStyle
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -771,6 +772,47 @@ class StyleTraversalIntegrationTest {
             runBlocking { innerSource.emit(FocusInteraction.Unfocus(innerFocus)) }
             waitForIdle()
             assertEquals(1f, inner.last.scale)
+            assertEquals(Color.Blue, inner.last.color)
+        }
+
+    @Test
+    fun nullSourceStyleDoesNotObserveAncestorInteractions() =
+        runComposeUiTest {
+            val outerSource = MutableInteractionSource()
+            val inner = StyleRecorder()
+            val innerStyle =
+                StyleDefaults.style(
+                    colors =
+                        StyleDefaults.colors(
+                            backgroundColor = Color.Blue,
+                            focusedBackgroundColor = Color.Red,
+                        ),
+                )
+
+            setContent {
+                Box(
+                    Modifier
+                        .size(1.dp)
+                        .interactionStyle(outerSource) { if (focused) color = Color.Red },
+                ) {
+                    Box(
+                        Modifier
+                            .size(1.dp)
+                            .interactionStyle(interactionSource = null, style = innerStyle)
+                            .recordStyle(inner),
+                    )
+                }
+            }
+            waitForIdle()
+            val innerUpdates = inner.snapshots.size
+            assertEquals(Color.Blue, inner.last.color)
+
+            runBlocking {
+                outerSource.emit(FocusInteraction.Focus())
+            }
+            waitForIdle()
+
+            assertEquals(innerUpdates, inner.snapshots.size)
             assertEquals(Color.Blue, inner.last.color)
         }
 }

--- a/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/StyleTraversalIntegrationTest.kt
+++ b/style/src/commonTest/kotlin/io.daio.wild.style/modifiers/StyleTraversalIntegrationTest.kt
@@ -28,6 +28,7 @@ import io.daio.wild.style.Border
 import io.daio.wild.style.BorderDefaults
 import io.daio.wild.style.StyleDefaults
 import io.daio.wild.style.interactionStyle
+import io.daio.wild.style.staticStyle
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -801,6 +802,42 @@ class StyleTraversalIntegrationTest {
                             .interactionStyle(interactionSource = null, style = innerStyle)
                             .recordStyle(inner),
                     )
+                }
+            }
+            waitForIdle()
+            val innerUpdates = inner.snapshots.size
+            assertEquals(Color.Blue, inner.last.color)
+
+            runBlocking {
+                outerSource.emit(FocusInteraction.Focus())
+            }
+            waitForIdle()
+
+            assertEquals(innerUpdates, inner.snapshots.size)
+            assertEquals(Color.Blue, inner.last.color)
+        }
+
+    @Test
+    fun staticStyleDoesNotObserveAncestorInteractions() =
+        runComposeUiTest {
+            val outerSource = MutableInteractionSource()
+            val inner = StyleRecorder()
+            val innerStyle =
+                StyleDefaults.style(
+                    colors =
+                        StyleDefaults.colors(
+                            backgroundColor = Color.Blue,
+                            focusedBackgroundColor = Color.Red,
+                        ),
+                )
+
+            setContent {
+                Box(
+                    Modifier
+                        .size(1.dp)
+                        .interactionStyle(outerSource) { if (focused) color = Color.Red },
+                ) {
+                    Box(Modifier.size(1.dp).staticStyle(innerStyle).recordStyle(inner))
                 }
             }
             waitForIdle()


### PR DESCRIPTION
Linear: https://linear.app/the-good-egg-studio/issue/THE-214/add-a-thinner-static-style-path-for-non-interactive-containers

## Summary
- Add a dedicated static style path for non-interactive containers.
- Omit InteractionSourceElement and block ancestor interaction traversal without changing interactive styles.
- Preserve the existing style-node chain for background, content color, shape, border, and alpha.

## Verification
- `./gradlew :style:jvmTest :layout:container:jvmTest`
- `./gradlew :style:spotlessCheck :layout:container:spotlessCheck`
- `./gradlew :style:metalavaCheckCompatibility :layout:container:metalavaCheckCompatibility`
- `git diff main...HEAD --check`

All passed locally.