### PR TITLE
fix(benchmark): harden TV release runner order and SHA attribution

### DIFF
--- a/benchmark_results/snapshots/2026-07-29_AFTR_local_short/README.md
+++ b/benchmark_results/snapshots/2026-07-29_AFTR_local_short/README.md
@@ -1,12 +1,17 @@
 # Snapshot: 2026-07-29 AFTR local_short
 
-First dated release-runner snapshot on the trusted AFTR Fire TV.
+Historical `local_short` archive from the first release-runner session on AFTR.
+
+**Do not use as a comparison baseline.** Captured before `waitUntilFocusedMarker`
+(Fire TV-safe focused-ancestor waits). Terminal markers may have been present without
+proven focus, so frame deltas are not trustworthy against the current harness.
 
 - Profile: `local_short` (exploration; not a confirmation claim)
 - Device: AFTR / Android 9
-- Git SHA at run time: `813fb73` (pre-rebase worktree SHA; branch later rebased onto `origin/main`)
-- Variants: `wild_clickable`, `wild_container` (Wild Container), `material_surface`
+- Git SHA at run time: `813fb73` (pre-focus-validation harness)
+- Variants: `wild_clickable`, `wild_container`, `material_surface`
 - Included: `session.json`, `summary.md`, per-variant `benchmarkData.json` + `message.txt`
-- Omitted: Perfetto traces (~200MB) — keep those local under `benchmark_results/sessions/`
+- Omitted: Perfetto traces
 
-Use this as the first human-comparison baseline. Confirmation-profile snapshots should be added separately before release claims.
+Replace with a new dated snapshot after a clean `local_short` run on AFTR once the
+device is reachable again (`./scripts/run-tv-style-benchmarks.sh --profile local_short`).

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -72,7 +72,9 @@ benchmark_results/snapshots/<yyyy-mm-dd>_<device>_<profile>/
 ```
 
 Those snapshots keep `session.json`, `summary.md`, and per-variant `benchmarkData.json` /
-`message.txt`, but omit Perfetto traces.
+`message.txt`, but omit Perfetto traces. Do not treat
+`benchmark_results/snapshots/2026-07-29_AFTR_local_short/` as a baseline — it predates
+focused-marker validation; capture a new dated snapshot after harness changes.
 
 **Confirmation / release profile (default):** warm startup, 20 measured iterations,
 `CompilationMode.Partial()`, full scroll path ending at `benchmark-item-5-20`, fixed ~50ms key pace,

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -44,7 +44,10 @@ Useful flags:
 
 - `--variants clickable,container,material` — subset of the release comparison set
 - `--serial <adb-serial>` — required when more than one device is connected
-- `--invocations N` — repeat the selected set for run-to-run variance
+- `--invocations N` — repeat the selected set; order rotates left each invocation to
+  counterbalance thermal / position bias (prefer `N` equal to the variant count)
+- `--allow-dirty` — permit uncommitted changes; session records `gitDirty: true`. Without
+  this flag the runner refuses a dirty worktree so `gitSha` matches the measured APK.
 
 Alias mapping:
 
@@ -80,9 +83,10 @@ claims in docs or PRs.
 ending at `benchmark-item-2-10`. Use for device bring-up and harness debugging only — not for
 release claims.
 
-The runner installs `:playbook:androidTv` before measuring, runs each selected variant in isolation,
-and copies outputs before the next Gradle run overwrites them. Summaries are report-only: no
-automatic pass/fail thresholds.
+The runner installs `:playbook:androidTv` before measuring, runs each selected variant in isolation
+(with per-invocation order rotation), and copies outputs before the next Gradle run overwrites them.
+Each invocation records its run `order` in `session.json`. Summaries are report-only: no automatic
+pass/fail thresholds.
 
 ## Deep-dive Gradle commands
 

--- a/scripts/run-tv-style-benchmarks.sh
+++ b/scripts/run-tv-style-benchmarks.sh
@@ -6,6 +6,7 @@ PROFILE="confirmation"
 SERIAL=""
 VARIANTS="clickable,container,material"
 INVOCATIONS=1
+ALLOW_DIRTY=0
 
 usage() {
   cat <<'EOF'
@@ -16,7 +17,11 @@ Options:
   --serial <adb-serial>                Required if multiple devices are connected
   --variants clickable,container,material
   --invocations <N>                    Repeat the selected set N times (default: 1)
+  --allow-dirty                        Allow uncommitted changes; session records gitDirty=true
   -h, --help                           Show help
+
+Variant order rotates left by (invocation - 1) so multi-invocation runs counterbalance
+thermal / position bias. Prefer --invocations equal to the variant count for release claims.
 EOF
 }
 
@@ -26,6 +31,7 @@ while [[ $# -gt 0 ]]; do
     --serial) SERIAL="${2:-}"; shift 2 ;;
     --variants) VARIANTS="${2:-}"; shift 2 ;;
     --invocations) INVOCATIONS="${2:-}"; shift 2 ;;
+    --allow-dirty) ALLOW_DIRTY=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *)
       echo "Unknown option: $1" >&2
@@ -43,6 +49,17 @@ fi
 if ! [[ "$INVOCATIONS" =~ ^[1-9][0-9]*$ ]]; then
   echo "--invocations must be a positive integer" >&2
   exit 1
+fi
+
+GIT_DIRTY=false
+if [[ -n "$(git -C "$ROOT_DIR" status --porcelain)" ]]; then
+  if [[ "$ALLOW_DIRTY" -eq 1 ]]; then
+    GIT_DIRTY=true
+    echo "Warning: dirty worktree; session will record gitDirty=true" >&2
+  else
+    echo "Refusing dirty worktree; commit/stash or pass --allow-dirty so gitSha matches the measured APK." >&2
+    exit 1
+  fi
 fi
 
 # Prints: <folder> <method>
@@ -118,6 +135,7 @@ run_variant() {
   invocation_dir="$SESSION_DIR/invocations/$(printf '%02d' "$invocation_index")"
   variant_dir="$invocation_dir/$folder"
   mkdir -p "$variant_dir/traces"
+  echo "$folder" >>"$invocation_dir/order.txt"
 
   local gradle_args=(
     :internal:benchmark:connectedCheck
@@ -154,23 +172,25 @@ run_variant() {
   find "$connected_dir" -maxdepth 1 -type f -name "TvBenchmarkTest_${method}_*.perfetto-trace" -exec cp {} "$variant_dir/traces/" \;
 }
 
+variant_count=${#SELECTED_ALIASES[@]}
 for ((i = 1; i <= INVOCATIONS; i++)); do
-  for alias in "${SELECTED_ALIASES[@]}"; do
-    run_variant "$i" "$alias"
+  offset=$(( (i - 1) % variant_count ))
+  for ((j = 0; j < variant_count; j++)); do
+    run_variant "$i" "${SELECTED_ALIASES[$(( (j + offset) % variant_count ))]}"
   done
 done
 
-python3 - "$ROOT_DIR" "$SESSION_DIR" "$PROFILE" "$MODEL" "$ANDROID_VERSION" "$GIT_SHA" "$COMPOSE_VERSION" "${SELECTED_FOLDERS[@]}" <<'PY'
+python3 - "$ROOT_DIR" "$SESSION_DIR" "$PROFILE" "$MODEL" "$ANDROID_VERSION" "$GIT_SHA" "$COMPOSE_VERSION" "$GIT_DIRTY" "${SELECTED_FOLDERS[@]}" <<'PY'
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
 session_dir = Path(sys.argv[2])
 profile, model, android, git_sha, compose = sys.argv[3:8]
-folders = sys.argv[8:]
+git_dirty = sys.argv[8].lower() == "true"
+folders = sys.argv[9:]
 
 sys.path.insert(0, str(root / "scripts"))
 from tv_benchmark_report import extract_variant_metrics, write_session_artifacts
@@ -185,17 +205,26 @@ session = {
     "profile": profile,
     "device": {"model": model, "androidVersion": android},
     "gitSha": git_sha,
+    "gitDirty": git_dirty,
     "composeVersion": compose,
     "variants": folders,
     "invocations": [],
 }
 
 for inv_dir in sorted(session_dir.glob("invocations/*")):
+    order_path = inv_dir / "order.txt"
+    order = [line.strip() for line in order_path.read_text().splitlines() if line.strip()] if order_path.exists() else list(folders)
     results = {}
     for folder in folders:
         data = inv_dir / folder / "benchmarkData.json"
         results[folder] = extract_variant_metrics(data, FOLDER_TO_METHOD[folder])
-    session["invocations"].append({"index": int(inv_dir.name), "results": results})
+    session["invocations"].append(
+        {
+            "index": int(inv_dir.name),
+            "order": order,
+            "results": results,
+        }
+    )
 
 write_session_artifacts(session_dir, session)
 print(session_dir / "summary.md")


### PR DESCRIPTION
## Summary
- Rotate variant order left by `(invocation - 1)` and record each invocation's `order` in `session.json`, so multi-invocation runs counterbalance thermal/position bias (prefer `--invocations` equal to the variant count).
- Refuse dirty worktrees by default so archived `gitSha` matches the measured APK; `--allow-dirty` records `gitDirty: true` when local exploration needs it.
- Mark `2026-07-29_AFTR_local_short` as untrusted for comparisons — it predates `waitUntilFocusedMarker`. AFTR was unreachable for a rerun; a new dated snapshot should replace it once the device is back.

Follow-up to review on #342 (merged).

## Test plan
- [ ] `./scripts/run-tv-style-benchmarks.sh --help` shows `--allow-dirty` and rotation note
- [ ] Dirty tree without `--allow-dirty` exits non-zero before install
- [ ] `--invocations 3` with three variants writes distinct `order` lists in each invocation dir / `session.json`
- [ ] When AFTR is reachable: `./scripts/run-tv-style-benchmarks.sh --profile local_short --invocations 1` and archive a new lean snapshot under `benchmark_results/snapshots/`